### PR TITLE
Initialize the global dimension reduction strategy and first tools on sklearn and umap

### DIFF
--- a/goldener/reduce.py
+++ b/goldener/reduce.py
@@ -1,0 +1,32 @@
+import torch
+
+from umap import UMAP
+from sklearn.decomposition import PCA
+from sklearn.manifold import TSNE
+from sklearn.random_projection import GaussianRandomProjection
+
+from goldener.torch_utils import torch_tensor_to_numpy_vectors, np_transform_from_torch
+
+
+class DimensionReduction:
+    """Dimensionality reduction using UMAP, PCA, TSNE, or GaussianRandomProjection.
+
+    Attributes:
+        reducer: An instance of UMAP, PCA, TSNE, or GaussianRandomProjection.
+    """
+
+    def __init__(self, reducer: UMAP | PCA | TSNE | GaussianRandomProjection):
+        self.reducer = reducer
+
+    def fit(self, x: torch.Tensor) -> None:
+        """Fit the dimensionality reduction model to the data."""
+        x_np = torch_tensor_to_numpy_vectors(x)
+        self.reducer.fit(x_np)
+
+    def fit_transform(self, x: torch.Tensor) -> torch.Tensor:
+        """Fit the dimensionality reduction model to the data."""
+        return np_transform_from_torch(x, self.reducer.fit_transform)
+
+    def transform(self, x: torch.Tensor) -> torch.Tensor:
+        """Transform the data using the fitted dimensionality reduction model."""
+        return np_transform_from_torch(x, self.reducer.transform)

--- a/goldener/torch_utils.py
+++ b/goldener/torch_utils.py
@@ -1,0 +1,100 @@
+from typing import Callable
+
+import numpy as np
+import torch
+
+
+def torch_tensor_to_numpy_vectors(x: torch.Tensor) -> np.ndarray:
+    """Convert a torch tensor to a numpy array of vectors.
+
+    If the input tensor is 0D, it is converted to a (1, 1) array.
+    If the input tensor is 1D, it is converted to a (N, 1) array.
+    If the input tensor is 2D, it is kept as (N, M) array.
+    If the input tensor is 3D or higher, the second dimension is moved to the last
+    dimension, and the first dimensions are flattened to form a 2D array of vectors.
+
+    Args:
+        x: Input tensor convert to numpy vectors.
+
+    Returns:
+        A 2D numpy array of shape (N, M)
+    """
+    initial_ndim = x.ndim
+    if initial_ndim == 0:
+        x = x.unsqueeze(0).unsqueeze(0)
+    elif initial_ndim == 1:
+        x = x.unsqueeze(1)
+
+    if x.ndim <= 2:
+        return x.cpu().numpy()
+
+    x = x.moveaxis(1, -1)
+    x.flatten(0, -2)
+    return x.cpu().numpy()
+
+
+def numpy_vectors_to_torch_tensor(
+    x: np.ndarray, shape: tuple[int, ...], dtype: torch.dtype, device: torch.device
+) -> torch.Tensor:
+    """Convert a numpy array to a torch tensor.
+
+    If the input array is 0D, it is converted to a (1, 1) tensor.
+    If the input array is 1D, it is converted to a (N, 1) tensor.
+    If the input array is 2D, it is kept as (N, M) tensor.
+    If the input array is 3D or higher, the last dimension is moved to the second
+    dimension, and the first dimensions are reshaped to form the desired shape.
+
+    Args:
+        x: Input numpy array to convert to torch tensor.
+        shape: Desired shape of the output tensor.
+        dtype: Desired data type of the output tensor.
+        device: Desired device of the output tensor.
+
+    Returns:
+        A torch tensor of the desired shape, dtype, and device.
+
+    Raises:
+        ValueError: If the desired shape is less than 2D.
+    """
+    if len(shape) < 2:
+        raise ValueError("Shape must be at least 2D")
+
+    if x.ndim <= 2:
+        return (
+            torch.from_numpy(x)
+            .to(
+                device=device,
+                dtype=dtype,
+            )
+            .reshape(shape)
+        )
+
+    x_torch = torch.from_numpy(x)
+    x_torch = x_torch.moveaxis(-1, 1)
+    x_torch = x_torch.reshape(shape)
+
+    return x_torch.to(
+        device=device,
+        dtype=dtype,
+    )
+
+
+def np_transform_from_torch(
+    x: torch.Tensor,
+    transform_np: Callable[[np.ndarray], np.ndarray],
+) -> torch.Tensor:
+    """Apply a numpy transformation to a torch tensor.
+
+    Args:
+        x: Input tensor to transform.
+        transform_np: A callable that takes a numpy array and returns a transformed
+            numpy array.
+
+    Returns:
+        A transformed torch tensor with the same dtype and device as the input tensor.
+    """
+    x_np = torch_tensor_to_numpy_vectors(x)
+    transformed = transform_np(x_np)
+    return numpy_vectors_to_torch_tensor(
+        transformed, shape=transformed.shape, dtype=x.dtype, device=x.device
+    )

--- a/mypy.ini
+++ b/mypy.ini
@@ -17,3 +17,7 @@ disallow_untyped_defs = false
 
 
 # libraries without expected type annotations
+[mypy-umap,umap.*]
+ignore_missing_imports = true
+[mypy-sklearn,sklearn.*]
+ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ dependencies = [
   "pixeltable",
   "ray[default, data]",
   "nvidia-ml-py",
+  "scikit-learn",
+  "umap-learn",
 ]
 
 [project.optional-dependencies]

--- a/test/test_reduce.py
+++ b/test/test_reduce.py
@@ -1,0 +1,62 @@
+import torch
+
+from goldener.reduce import DimensionReduction
+from umap import UMAP
+from sklearn.decomposition import PCA
+from sklearn.manifold import TSNE
+from sklearn.random_projection import GaussianRandomProjection
+
+
+def test_pca():
+    data = torch.randn(10, 5, dtype=torch.float32)
+    reducer = PCA(n_components=3)
+    dr = DimensionReduction(reducer)
+    # Test fit + transform
+    dr.fit(data)
+    out = dr.transform(data)
+    assert isinstance(out, torch.Tensor)
+    assert out.shape == (data.shape[0], 3)
+    # Test fit_transform
+    out2 = dr.fit_transform(data)
+    assert isinstance(out2, torch.Tensor)
+    assert out2.shape == (data.shape[0], 3)
+
+
+def test_tsne():
+    data = torch.randn(10, 5, dtype=torch.float32)
+    reducer = TSNE(n_components=2, perplexity=3)
+    dr = DimensionReduction(reducer)
+    # TSNE does not have transform, only fit_transform
+    out = dr.fit_transform(data)
+    assert isinstance(out, torch.Tensor)
+    assert out.shape == (data.shape[0], 2)
+
+
+def test_umap():
+    data = torch.randn(10, 5, dtype=torch.float32)
+    reducer = UMAP(n_components=2)
+    dr = DimensionReduction(reducer)
+    # Test fit + transform
+    dr.fit(data)
+    out = dr.transform(data)
+    assert isinstance(out, torch.Tensor)
+    assert out.shape == (data.shape[0], 2)
+    # Test fit_transform
+    out2 = dr.fit_transform(data)
+    assert isinstance(out2, torch.Tensor)
+    assert out2.shape == (data.shape[0], 2)
+
+
+def test_gaussian_random_projection():
+    data = torch.randn(10, 5, dtype=torch.float32)
+    reducer = GaussianRandomProjection(n_components=4)
+    dr = DimensionReduction(reducer)
+    # Test fit + transform
+    dr.fit(data)
+    out = dr.transform(data)
+    assert isinstance(out, torch.Tensor)
+    assert out.shape == (data.shape[0], 4)
+    # Test fit_transform
+    out2 = dr.fit_transform(data)
+    assert isinstance(out2, torch.Tensor)
+    assert out2.shape == (data.shape[0], 4)

--- a/test/test_torch_utils.py
+++ b/test/test_torch_utils.py
@@ -1,0 +1,96 @@
+import numpy as np
+import torch
+import pytest
+from goldener.torch_utils import (
+    torch_tensor_to_numpy_vectors,
+    numpy_vectors_to_torch_tensor,
+    np_transform_from_torch,
+)
+
+
+class TestTensorToVector:
+    def test_torch_tensor_to_numpy_vectors_0d(self):
+        t = torch.tensor(3)
+        arr = torch_tensor_to_numpy_vectors(t)
+        assert isinstance(arr, np.ndarray)
+        assert arr.shape == (1, 1)
+
+    def test_torch_tensor_to_numpy_vectors_1d(self):
+        t = torch.rand(3)
+        arr = torch_tensor_to_numpy_vectors(t)
+        assert isinstance(arr, np.ndarray)
+        assert arr.shape == (3, 1)
+
+    def test_torch_tensor_to_numpy_vectors_2d(self):
+        t = torch.rand(3, 2)
+        arr = torch_tensor_to_numpy_vectors(t)
+        assert isinstance(arr, np.ndarray)
+        assert arr.shape == (3, 2)
+
+    def test_torch_tensor_to_numpy_vectors_3d(self):
+        t = torch.rand(2, 3, 4, dtype=torch.float32)
+        arr = torch_tensor_to_numpy_vectors(t)
+        assert arr.shape == (2, 4, 3)
+
+
+class TestArrayToTensor:
+    def test_numpy_vectors_to_torch_tensor_0d(self):
+        arr = np.array(3)
+        shape = (1, 1)
+        t = numpy_vectors_to_torch_tensor(
+            arr, shape, torch.float32, torch.device("cpu")
+        )
+        assert isinstance(t, torch.Tensor)
+        assert t.shape == shape
+        assert t.device.type == "cpu"
+        assert t.dtype == torch.float32
+
+    def test_numpy_vectors_to_torch_tensor_1d(self):
+        arr = np.random.randint(0, 10, size=(3,), dtype=np.int32)
+        shape = (3, 1)
+        t = numpy_vectors_to_torch_tensor(
+            arr, shape, torch.float32, torch.device("cpu")
+        )
+        assert isinstance(t, torch.Tensor)
+        assert t.shape == shape
+        assert t.device.type == "cpu"
+        assert t.dtype == torch.float32
+
+    def test_numpy_vectors_to_torch_tensor_2d(self):
+        arr = np.random.randint(0, 10, size=(3, 2), dtype=np.int32)
+        shape = (3, 2)
+        t = numpy_vectors_to_torch_tensor(
+            arr, shape, torch.float32, torch.device("cpu")
+        )
+        assert isinstance(t, torch.Tensor)
+        assert t.shape == shape
+        assert t.device.type == "cpu"
+        assert t.dtype == torch.float32
+
+    def test_numpy_vectors_to_torch_tensor_3d(self):
+        arr = np.random.rand(2, 4, 3).astype(np.float32)
+        shape = (2, 3, 4)  # Desired shape with channel moved to 1st dimension
+        t = numpy_vectors_to_torch_tensor(
+            arr, shape, torch.float32, torch.device("cpu")
+        )
+        assert isinstance(t, torch.Tensor)
+        assert t.shape == shape
+        assert t.device.type == "cpu"
+        assert t.dtype == torch.float32
+
+    def test_numpy_vectors_to_torch_tensor_invalid_shape(self):
+        arr = np.random.rand(
+            3,
+        )
+        with pytest.raises(ValueError):
+            numpy_vectors_to_torch_tensor(arr, (3,), torch.float32, torch.device("cpu"))
+
+
+class TestNpTranformFromTorch:
+    def test_np_transform_from_torch(self):
+        def dummy_transform(x: np.ndarray) -> np.ndarray:
+            return x + 1
+
+        t = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+        out = np_transform_from_torch(t, dummy_transform)
+        assert out.shape == t.shape

--- a/uv.lock
+++ b/uv.lock
@@ -322,7 +322,9 @@ dependencies = [
     { name = "nvidia-ml-py" },
     { name = "pixeltable" },
     { name = "ray", extra = ["data", "default"] },
+    { name = "scikit-learn" },
     { name = "torch" },
+    { name = "umap-learn" },
 ]
 
 [package.optional-dependencies]
@@ -345,9 +347,11 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "ray", extras = ["default", "data"] },
     { name = "ruff", marker = "extra == 'dev'" },
+    { name = "scikit-learn" },
     { name = "torch" },
     { name = "types-pillow", marker = "extra == 'dev'" },
     { name = "types-tqdm", marker = "extra == 'dev'" },
+    { name = "umap-learn" },
 ]
 provides-extras = ["dev"]
 
@@ -529,6 +533,15 @@ wheels = [
 ]
 
 [[package]]
+name = "joblib"
+version = "1.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/5d/447af5ea094b9e4c4054f82e223ada074c552335b9b4b2d14bd9b35a67c4/joblib-1.5.2.tar.gz", hash = "sha256:3faa5c39054b2f03ca547da9b2f52fde67c06240c31853f306aea97f13647b55", size = 331077, upload-time = "2025-08-27T12:15:46.575Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/e8/685f47e0d754320684db4425a0967f7d3fa70126bffd76110b7009a0090f/joblib-1.5.2-py3-none-any.whl", hash = "sha256:4e1f0bdbb987e6d843c70cf43714cb276623def372df3c22fe5266b2670bc241", size = 308396, upload-time = "2025-08-27T12:15:45.188Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.25.1"
 source = { registry = "https://pypi.org/simple" }
@@ -553,6 +566,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "llvmlite"
+version = "0.45.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/8d/5baf1cef7f9c084fb35a8afbde88074f0d6a727bc63ef764fe0e7543ba40/llvmlite-0.45.1.tar.gz", hash = "sha256:09430bb9d0bb58fc45a45a57c7eae912850bedc095cd0810a57de109c69e1c32", size = 185600, upload-time = "2025-10-01T17:59:52.046Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/e2/c185bb7e88514d5025f93c6c4092f6120c6cea8fe938974ec9860fb03bbb/llvmlite-0.45.1-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:d9ea9e6f17569a4253515cc01dade70aba536476e3d750b2e18d81d7e670eb15", size = 43043524, upload-time = "2025-10-01T18:03:43.249Z" },
+    { url = "https://files.pythonhosted.org/packages/09/b8/b5437b9ecb2064e89ccf67dccae0d02cd38911705112dd0dcbfa9cd9a9de/llvmlite-0.45.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:c9f3cadee1630ce4ac18ea38adebf2a4f57a89bd2740ce83746876797f6e0bfb", size = 37253121, upload-time = "2025-10-01T18:04:30.557Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/97/ad1a907c0173a90dd4df7228f24a3ec61058bc1a9ff8a0caec20a0cc622e/llvmlite-0.45.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:57c48bf2e1083eedbc9406fb83c4e6483017879714916fe8be8a72a9672c995a", size = 56288210, upload-time = "2025-10-01T18:01:40.26Z" },
+    { url = "https://files.pythonhosted.org/packages/32/d8/c99c8ac7a326e9735401ead3116f7685a7ec652691aeb2615aa732b1fc4a/llvmlite-0.45.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3aa3dfceda4219ae39cf18806c60eeb518c1680ff834b8b311bd784160b9ce40", size = 55140957, upload-time = "2025-10-01T18:02:46.244Z" },
+    { url = "https://files.pythonhosted.org/packages/09/56/ed35668130e32dbfad2eb37356793b0a95f23494ab5be7d9bf5cb75850ee/llvmlite-0.45.1-cp313-cp313-win_amd64.whl", hash = "sha256:080e6f8d0778a8239cd47686d402cb66eb165e421efa9391366a9b7e5810a38b", size = 38132232, upload-time = "2025-10-01T18:05:14.477Z" },
 ]
 
 [[package]]
@@ -743,6 +769,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437, upload-time = "2024-06-04T18:44:11.171Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314, upload-time = "2024-06-04T18:44:08.352Z" },
+]
+
+[[package]]
+name = "numba"
+version = "0.62.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "llvmlite" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/20/33dbdbfe60e5fd8e3dbfde299d106279a33d9f8308346022316781368591/numba-0.62.1.tar.gz", hash = "sha256:7b774242aa890e34c21200a1fc62e5b5757d5286267e71103257f4e2af0d5161", size = 2749817, upload-time = "2025-09-29T10:46:31.551Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/76/501ea2c07c089ef1386868f33dff2978f43f51b854e34397b20fc55e0a58/numba-0.62.1-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:b72489ba8411cc9fdcaa2458d8f7677751e94f0109eeb53e5becfdc818c64afb", size = 2685766, upload-time = "2025-09-29T10:43:49.161Z" },
+    { url = "https://files.pythonhosted.org/packages/80/68/444986ed95350c0611d5c7b46828411c222ce41a0c76707c36425d27ce29/numba-0.62.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:44a1412095534a26fb5da2717bc755b57da5f3053965128fe3dc286652cc6a92", size = 2688741, upload-time = "2025-09-29T10:44:10.07Z" },
+    { url = "https://files.pythonhosted.org/packages/78/7e/bf2e3634993d57f95305c7cee4c9c6cb3c9c78404ee7b49569a0dfecfe33/numba-0.62.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8c9460b9e936c5bd2f0570e20a0a5909ee6e8b694fd958b210e3bde3a6dba2d7", size = 3804576, upload-time = "2025-09-29T10:42:59.53Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/b6/8a1723fff71f63bbb1354bdc60a1513a068acc0f5322f58da6f022d20247/numba-0.62.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:728f91a874192df22d74e3fd42c12900b7ce7190b1aad3574c6c61b08313e4c5", size = 3503367, upload-time = "2025-09-29T10:43:26.326Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/ec/9d414e7a80d6d1dc4af0e07c6bfe293ce0b04ea4d0ed6c45dad9bd6e72eb/numba-0.62.1-cp313-cp313-win_amd64.whl", hash = "sha256:bbf3f88b461514287df66bc8d0307e949b09f2b6f67da92265094e8fa1282dd8", size = 2745529, upload-time = "2025-09-29T10:44:31.738Z" },
 ]
 
 [[package]]
@@ -1428,6 +1471,22 @@ wheels = [
 ]
 
 [[package]]
+name = "pynndescent"
+version = "0.5.13"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "llvmlite" },
+    { name = "numba" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/58/560a4db5eb3794d922fe55804b10326534ded3d971e1933c1eef91193f5e/pynndescent-0.5.13.tar.gz", hash = "sha256:d74254c0ee0a1eeec84597d5fe89fedcf778593eeabe32c2f97412934a9800fb", size = 2975955, upload-time = "2024-06-17T15:48:32.914Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/53/d23a97e0a2c690d40b165d1062e2c4ccc796be458a1ce59f6ba030434663/pynndescent-0.5.13-py3-none-any.whl", hash = "sha256:69aabb8f394bc631b6ac475a1c7f3994c54adf3f51cd63b2730fefba5771b949", size = 56850, upload-time = "2024-06-17T15:48:31.184Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "8.3.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1628,6 +1687,61 @@ wheels = [
 ]
 
 [[package]]
+name = "scikit-learn"
+version = "1.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "threadpoolctl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/c2/a7855e41c9d285dfe86dc50b250978105dce513d6e459ea66a6aeb0e1e0c/scikit_learn-1.7.2.tar.gz", hash = "sha256:20e9e49ecd130598f1ca38a1d85090e1a600147b9c02fa6f15d69cb53d968fda", size = 7193136, upload-time = "2025-09-09T08:21:29.075Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/93/a3038cb0293037fd335f77f31fe053b89c72f17b1c8908c576c29d953e84/scikit_learn-1.7.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0b7dacaa05e5d76759fb071558a8b5130f4845166d88654a0f9bdf3eb57851b7", size = 9212382, upload-time = "2025-09-09T08:20:54.731Z" },
+    { url = "https://files.pythonhosted.org/packages/40/dd/9a88879b0c1104259136146e4742026b52df8540c39fec21a6383f8292c7/scikit_learn-1.7.2-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:abebbd61ad9e1deed54cca45caea8ad5f79e1b93173dece40bb8e0c658dbe6fe", size = 8592042, upload-time = "2025-09-09T08:20:57.313Z" },
+    { url = "https://files.pythonhosted.org/packages/46/af/c5e286471b7d10871b811b72ae794ac5fe2989c0a2df07f0ec723030f5f5/scikit_learn-1.7.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:502c18e39849c0ea1a5d681af1dbcf15f6cce601aebb657aabbfe84133c1907f", size = 9434180, upload-time = "2025-09-09T08:20:59.671Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/fd/df59faa53312d585023b2da27e866524ffb8faf87a68516c23896c718320/scikit_learn-1.7.2-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7a4c328a71785382fe3fe676a9ecf2c86189249beff90bf85e22bdb7efaf9ae0", size = 9283660, upload-time = "2025-09-09T08:21:01.71Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/c7/03000262759d7b6f38c836ff9d512f438a70d8a8ddae68ee80de72dcfb63/scikit_learn-1.7.2-cp313-cp313-win_amd64.whl", hash = "sha256:63a9afd6f7b229aad94618c01c252ce9e6fa97918c5ca19c9a17a087d819440c", size = 8702057, upload-time = "2025-09-09T08:21:04.234Z" },
+    { url = "https://files.pythonhosted.org/packages/55/87/ef5eb1f267084532c8e4aef98a28b6ffe7425acbfd64b5e2f2e066bc29b3/scikit_learn-1.7.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:9acb6c5e867447b4e1390930e3944a005e2cb115922e693c08a323421a6966e8", size = 9558731, upload-time = "2025-09-09T08:21:06.381Z" },
+    { url = "https://files.pythonhosted.org/packages/93/f8/6c1e3fc14b10118068d7938878a9f3f4e6d7b74a8ddb1e5bed65159ccda8/scikit_learn-1.7.2-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:2a41e2a0ef45063e654152ec9d8bcfc39f7afce35b08902bfe290c2498a67a6a", size = 9038852, upload-time = "2025-09-09T08:21:08.628Z" },
+    { url = "https://files.pythonhosted.org/packages/83/87/066cafc896ee540c34becf95d30375fe5cbe93c3b75a0ee9aa852cd60021/scikit_learn-1.7.2-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:98335fb98509b73385b3ab2bd0639b1f610541d3988ee675c670371d6a87aa7c", size = 9527094, upload-time = "2025-09-09T08:21:11.486Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/2b/4903e1ccafa1f6453b1ab78413938c8800633988c838aa0be386cbb33072/scikit_learn-1.7.2-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:191e5550980d45449126e23ed1d5e9e24b2c68329ee1f691a3987476e115e09c", size = 9367436, upload-time = "2025-09-09T08:21:13.602Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/aa/8444be3cfb10451617ff9d177b3c190288f4563e6c50ff02728be67ad094/scikit_learn-1.7.2-cp313-cp313t-win_amd64.whl", hash = "sha256:57dc4deb1d3762c75d685507fbd0bc17160144b2f2ba4ccea5dc285ab0d0e973", size = 9275749, upload-time = "2025-09-09T08:21:15.96Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.16.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/3b/546a6f0bfe791bbb7f8d591613454d15097e53f906308ec6f7c1ce588e8e/scipy-1.16.2.tar.gz", hash = "sha256:af029b153d243a80afb6eabe40b0a07f8e35c9adc269c019f364ad747f826a6b", size = 30580599, upload-time = "2025-09-11T17:48:08.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/27/c5b52f1ee81727a9fc457f5ac1e9bf3d6eab311805ea615c83c27ba06400/scipy-1.16.2-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:84f7bf944b43e20b8a894f5fe593976926744f6c185bacfcbdfbb62736b5cc70", size = 36604856, upload-time = "2025-09-11T17:41:47.695Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a9/15c20d08e950b540184caa8ced675ba1128accb0e09c653780ba023a4110/scipy-1.16.2-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:5c39026d12edc826a1ef2ad35ad1e6d7f087f934bb868fc43fa3049c8b8508f9", size = 28864626, upload-time = "2025-09-11T17:41:52.642Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fc/ea36098df653cca26062a627c1a94b0de659e97127c8491e18713ca0e3b9/scipy-1.16.2-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:e52729ffd45b68777c5319560014d6fd251294200625d9d70fd8626516fc49f5", size = 20855689, upload-time = "2025-09-11T17:41:57.886Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/6f/d0b53be55727f3e6d7c72687ec18ea6d0047cf95f1f77488b99a2bafaee1/scipy-1.16.2-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:024dd4a118cccec09ca3209b7e8e614931a6ffb804b2a601839499cb88bdf925", size = 23512151, upload-time = "2025-09-11T17:42:02.303Z" },
+    { url = "https://files.pythonhosted.org/packages/11/85/bf7dab56e5c4b1d3d8eef92ca8ede788418ad38a7dc3ff50262f00808760/scipy-1.16.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7a5dc7ee9c33019973a470556081b0fd3c9f4c44019191039f9769183141a4d9", size = 33329824, upload-time = "2025-09-11T17:42:07.549Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6a/1a927b14ddc7714111ea51f4e568203b2bb6ed59bdd036d62127c1a360c8/scipy-1.16.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c2275ff105e508942f99d4e3bc56b6ef5e4b3c0af970386ca56b777608ce95b7", size = 35681881, upload-time = "2025-09-11T17:42:13.255Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/5f/331148ea5780b4fcc7007a4a6a6ee0a0c1507a796365cc642d4d226e1c3a/scipy-1.16.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:af80196eaa84f033e48444d2e0786ec47d328ba00c71e4299b602235ffef9acb", size = 36006219, upload-time = "2025-09-11T17:42:18.765Z" },
+    { url = "https://files.pythonhosted.org/packages/46/3a/e991aa9d2aec723b4a8dcfbfc8365edec5d5e5f9f133888067f1cbb7dfc1/scipy-1.16.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9fb1eb735fe3d6ed1f89918224e3385fbf6f9e23757cacc35f9c78d3b712dd6e", size = 38682147, upload-time = "2025-09-11T17:42:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/57/0f38e396ad19e41b4c5db66130167eef8ee620a49bc7d0512e3bb67e0cab/scipy-1.16.2-cp313-cp313-win_amd64.whl", hash = "sha256:fda714cf45ba43c9d3bae8f2585c777f64e3f89a2e073b668b32ede412d8f52c", size = 38520766, upload-time = "2025-09-11T17:43:25.342Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/a5/85d3e867b6822d331e26c862a91375bb7746a0b458db5effa093d34cdb89/scipy-1.16.2-cp313-cp313-win_arm64.whl", hash = "sha256:2f5350da923ccfd0b00e07c3e5cfb316c1c0d6c1d864c07a72d092e9f20db104", size = 25451169, upload-time = "2025-09-11T17:43:30.198Z" },
+    { url = "https://files.pythonhosted.org/packages/09/d9/60679189bcebda55992d1a45498de6d080dcaf21ce0c8f24f888117e0c2d/scipy-1.16.2-cp313-cp313t-macosx_10_14_x86_64.whl", hash = "sha256:53d8d2ee29b925344c13bda64ab51785f016b1b9617849dac10897f0701b20c1", size = 37012682, upload-time = "2025-09-11T17:42:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/83/be/a99d13ee4d3b7887a96f8c71361b9659ba4ef34da0338f14891e102a127f/scipy-1.16.2-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:9e05e33657efb4c6a9d23bd8300101536abd99c85cca82da0bffff8d8764d08a", size = 29389926, upload-time = "2025-09-11T17:42:35.845Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/0a/130164a4881cec6ca8c00faf3b57926f28ed429cd6001a673f83c7c2a579/scipy-1.16.2-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:7fe65b36036357003b3ef9d37547abeefaa353b237e989c21027b8ed62b12d4f", size = 21381152, upload-time = "2025-09-11T17:42:40.07Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a6/503ffb0310ae77fba874e10cddfc4a1280bdcca1d13c3751b8c3c2996cf8/scipy-1.16.2-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:6406d2ac6d40b861cccf57f49592f9779071655e9f75cd4f977fa0bdd09cb2e4", size = 23914410, upload-time = "2025-09-11T17:42:44.313Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c7/1147774bcea50d00c02600aadaa919facbd8537997a62496270133536ed6/scipy-1.16.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ff4dc42bd321991fbf611c23fc35912d690f731c9914bf3af8f417e64aca0f21", size = 33481880, upload-time = "2025-09-11T17:42:49.325Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/74/99d5415e4c3e46b2586f30cdbecb95e101c7192628a484a40dd0d163811a/scipy-1.16.2-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:654324826654d4d9133e10675325708fb954bc84dae6e9ad0a52e75c6b1a01d7", size = 35791425, upload-time = "2025-09-11T17:42:54.711Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/ee/a6559de7c1cc710e938c0355d9d4fbcd732dac4d0d131959d1f3b63eb29c/scipy-1.16.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:63870a84cd15c44e65220eaed2dac0e8f8b26bbb991456a033c1d9abfe8a94f8", size = 36178622, upload-time = "2025-09-11T17:43:00.375Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/7b/f127a5795d5ba8ece4e0dce7d4a9fb7cb9e4f4757137757d7a69ab7d4f1a/scipy-1.16.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:fa01f0f6a3050fa6a9771a95d5faccc8e2f5a92b4a2e5440a0fa7264a2398472", size = 38783985, upload-time = "2025-09-11T17:43:06.661Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/9f/bc81c1d1e033951eb5912cd3750cc005943afa3e65a725d2443a3b3c4347/scipy-1.16.2-cp313-cp313t-win_amd64.whl", hash = "sha256:116296e89fba96f76353a8579820c2512f6e55835d3fad7780fece04367de351", size = 38631367, upload-time = "2025-09-11T17:43:14.44Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5e/2cc7555fd81d01814271412a1d59a289d25f8b63208a0a16c21069d55d3e/scipy-1.16.2-cp313-cp313t-win_arm64.whl", hash = "sha256:98e22834650be81d42982360382b43b17f7ba95e0e6993e2a4f5b9ad9283a94d", size = 25787992, upload-time = "2025-09-11T17:43:19.745Z" },
+]
+
+[[package]]
 name = "setuptools"
 version = "78.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1715,6 +1829,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0a/d4/2b0cd0fe285e14b36db076e78c93766ff1d529d70408bd1d2a5a84f1d929/tenacity-9.1.2.tar.gz", hash = "sha256:1169d376c297e7de388d18b4481760d478b0e99a777cad3a9c86e556f4b697cb", size = 48036, upload-time = "2025-04-02T08:25:09.966Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/30/643397144bfbfec6f6ef821f36f33e57d35946c44a2352d3c9f0ae847619/tenacity-9.1.2-py3-none-any.whl", hash = "sha256:f77bf36710d8b73a50b2dd155c97b870017ad21afe6ab300326b0371b3b05138", size = 28248, upload-time = "2025-04-02T08:25:07.678Z" },
+]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
 ]
 
 [[package]]
@@ -1841,6 +1964,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/95/32/1a225d6164441be760d75c2c42e2780dc0873fe382da3e98a2e1e48361e5/tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9", size = 196380, upload-time = "2025-03-23T13:54:43.652Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/23/c7abc0ca0a1526a0774eca151daeb8de62ec457e77262b66b359c3c7679e/tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8", size = 347839, upload-time = "2025-03-23T13:54:41.845Z" },
+]
+
+[[package]]
+name = "umap-learn"
+version = "0.5.9.post2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numba" },
+    { name = "numpy" },
+    { name = "pynndescent" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/ee/6bc65bd375c812026a7af63fe9d09d409382120aff25f2152f1ba12af5ec/umap_learn-0.5.9.post2.tar.gz", hash = "sha256:bdf60462d779bd074ce177a0714ced17e6d161285590fa487f3f9548dd3c31c9", size = 95441, upload-time = "2025-07-03T00:18:02.479Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/b1/c24deeda9baf1fd491aaad941ed89e0fed6c583a117fd7b79e0a33a1e6c0/umap_learn-0.5.9.post2-py3-none-any.whl", hash = "sha256:fbe51166561e0e7fab00ef3d516ac2621243b8d15cf4bef9f656d701736b16a0", size = 90146, upload-time = "2025-07-03T00:18:01.042Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request introduces a new dimensionality reduction module and supporting utilities for seamless integration between PyTorch tensors and common scikit-learn/UMAP dimensionality reduction techniques. It also updates type annotations, dependencies, and testing to ensure robust support for these new features.

**New functionality for dimensionality reduction:**

* Added `goldener/reduce.py` with a `DimensionReduction` class supporting UMAP, PCA, TSNE, and GaussianRandomProjection, providing a unified interface for fitting and transforming PyTorch tensors with these reducers.
* Introduced `goldener/torch_utils.py` with utility functions for converting between PyTorch tensors and NumPy arrays, and for applying NumPy-based transformations to PyTorch tensors.

**Testing and validation:**

* Added comprehensive tests for the new dimensionality reduction and tensor/array conversion utilities in `test/test_reduce.py` and `test/test_torch_utils.py`. [[1]](diffhunk://#diff-ac6aebf17d5d7297be24b06a82c364a990c9649a294ef24f21be75584ea14c52R1-R62) [[2]](diffhunk://#diff-626788e66066598c365a4ce9b020200772da8edbcb1ca47aa7a2cf43f7aa2e35R1-R96)

**Dependency and configuration updates:**

* Added `scikit-learn` and `umap-learn` as required dependencies in `pyproject.toml` and updated `mypy.ini` to ignore missing type annotations for these libraries. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R16-R17) [[2]](diffhunk://#diff-6f2d4ba9ca9a357d31014946667b7bed1bfdbc6d2530afc77778fa0a36bee457R20-R23)

**Refactoring for clarity and consistency:**

* Updated function and argument names in `goldener/extract.py` for clarity (e.g., renaming `data` to `x`), improving code readability and consistency with new utilities. [[1]](diffhunk://#diff-29c1033040b7a17579acd03acd6ca762b93163a52824da7571dca7d6df9a6ad7L133-R157) [[2]](diffhunk://#diff-29c1033040b7a17579acd03acd6ca762b93163a52824da7571dca7d6df9a6ad7L211-R229) [[3]](diffhunk://#diff-29c1033040b7a17579acd03acd6ca762b93163a52824da7571dca7d6df9a6ad7L303-R313)