### PR TITLE
Remove useless elements in mypy.ini

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -9,9 +9,6 @@ warn_unused_configs = true
 local_partial_types = true
 
 
-[mypy-gold_anomaly,gold_anomaly.*,]
-disallow_untyped_defs = true
-
 [mypy-tests.*,examples.*, tools.*]
 disallow_untyped_defs = false
 


### PR DESCRIPTION
This pull request makes a minor configuration change to the `mypy.ini` file, specifically removing the rule that disallowed untyped function definitions for the `gold_anomaly` package. This will allow functions in `gold_anomaly` to have untyped definitions without causing mypy errors.