### PR TITLE
In GoldDescriptor, when the `idx` is not present in the dataset batch add it accordingly

### DIFF
--- a/goldener/describe.py
+++ b/goldener/describe.py
@@ -146,12 +146,13 @@ class GoldDescriptor:
             num_workers=self.num_workers if self.num_workers is not None else 0,
             collate_fn=self.collate_fn,
         )
-        for batch in dataloader:
+        for batch_idx, batch in enumerate(dataloader):
             batch["features"] = self.extractor.extract_and_fuse(
                 batch["data"].to(device=self.device)
             )
             if "idx" not in batch:
-                batch["idx"] = [idx for idx in range(len(batch["data"]))]
+                start = batch_idx * self.batch_size
+                batch["idx"] = [start + idx for idx in range(len(batch["data"]))]
             pxt_table.insert(
                 [
                     {

--- a/tests/test_describe.py
+++ b/tests/test_describe.py
@@ -27,12 +27,13 @@ def extractor():
 
 
 class DummyDataset:
-    def __init__(self, output_shape=(3, 2, 2)):
+    def __init__(self, output_shape: tuple[int, ...] = (3, 2, 2), dataset_len: int = 2):
+        self.dataset_len = dataset_len
         # produce a fixed tensor
         self.output_shape = output_shape
 
     def __len__(self):
-        return 2
+        return self.dataset_len
 
     def __getitem__(self, idx):
         return {"data": torch.zeros(3, 8, 8), "idx": idx, "label": "dummy"}
@@ -78,9 +79,9 @@ class TestGoldDescriptor:
         )
 
         table = desc.describe(
-            DummyDataset(),
+            DummyDataset(dataset_len=10),
         )
-        assert table.count() == 2
+        assert table.count() == 10
         for i, row in enumerate(table.collect()):
             assert row["idx"] == i
 


### PR DESCRIPTION
fix: https://github.com/goldener-data/goldener/issues/41

This pull request updates the batch indexing logic in the sequential description process and improves the test coverage for variable dataset lengths. The main focus is on ensuring that the indices assigned to each data item are accurate and reflect their position in the overall dataset, especially when batching is used.

**Batch Indexing and Dataset Handling Improvements:**

* Updated the batch processing loop in `_sequential_describe` (`goldener/describe.py`) to compute the correct global indices for each item in a batch, ensuring that `batch["idx"]` reflects the item's position in the full dataset rather than just within the batch.

**Test Enhancements:**

* Modified the `DummyDataset` class in the test suite to allow for configurable dataset lengths, making tests more flexible and realistic.
* Updated the test for the description process to use a dataset of length 10 and assert that all indices are correctly assigned, improving coverage for datasets larger than a single batch.