### PR TITLE
Allow to have an optional vectorizer in GoldSplitter

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -749,7 +749,7 @@ wheels = [
 
 [[package]]
 name = "goldener"
-version = "1.2.0"
+version = "2.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "coreax" },


### PR DESCRIPTION
This pull request improves the flexibility and robustness of the `GoldSplitter` class by making the `vectorizer` parameter optional and updating the logic throughout the class to handle cases where a vectorizer is not provided. Additionally, a new test is added to verify correct behavior when the descriptor itself handles vectorization. The most important changes are:

### Core logic and API improvements

* Made the `vectorizer` attribute and constructor parameter in `GoldSplitter` optional, updating type hints and docstrings accordingly to reflect that `vectorizer` can be `None`. [[1]](diffhunk://#diff-d1c1f9e2375dc6c25aaa7b9fb1f5b90b718704fe94d4bdd77ee731abca240d92L62-R62) [[2]](diffhunk://#diff-d1c1f9e2375dc6c25aaa7b9fb1f5b90b718704fe94d4bdd77ee731abca240d92L76-R76) [[3]](diffhunk://#diff-d1c1f9e2375dc6c25aaa7b9fb1f5b90b718704fe94d4bdd77ee731abca240d92L88-R88)
* Updated methods in `GoldSplitter` to handle the absence of a vectorizer, including conditional logic for setting `allow_existing`, vectorizing tables, and dropping tables. [[1]](diffhunk://#diff-d1c1f9e2375dc6c25aaa7b9fb1f5b90b718704fe94d4bdd77ee731abca240d92R126) [[2]](diffhunk://#diff-d1c1f9e2375dc6c25aaa7b9fb1f5b90b718704fe94d4bdd77ee731abca240d92L298-R307) [[3]](diffhunk://#diff-d1c1f9e2375dc6c25aaa7b9fb1f5b90b718704fe94d4bdd77ee731abca240d92L371-R381) [[4]](diffhunk://#diff-d1c1f9e2375dc6c25aaa7b9fb1f5b90b718704fe94d4bdd77ee731abca240d92L391-R408)

### Testing

* Added a new test `test_with_descriptor_including_vectorizer` to verify that `GoldSplitter` works correctly when the descriptor includes its own vectorizer and the `vectorizer` argument is set to `None`.