### PR TITLE
Update the coreset method to a greedy one (quick fix before more experiments)

### DIFF
--- a/goldener/select.py
+++ b/goldener/select.py
@@ -73,6 +73,7 @@ class GoldSelector:
         drop_table: Whether to drop the selection table after creating the dataset with selection results. It is only applied
             when using `select_in_dataset`. Default is False.
         max_batches: Optional maximum number of batches to process. Useful for testing on a small subset of the dataset.
+        seed: Random seed for selection reproducibility. Default is 42.
     """
 
     _MINIMAL_SCHEMA: dict[str, type] = {
@@ -851,7 +852,7 @@ class GoldSelector:
     def _coresubset_selection(
         self, x: torch.Tensor, select_count: int, indices: torch.Tensor
     ) -> set[int]:
-        """Apply kernel herding coresubset selection algorithm.
+        """Apply kernel coresubset selection.
 
         This private method uses the coreax library's GreedyKernelPoints solver with a
         LinearKernel to select a diverse subset of vectors.


### PR DESCRIPTION
This pull request updates the core subset selection algorithm in the `GoldSelector` class to use a different method and kernel, and introduces a random seed for reproducibility. The most important changes are grouped below:

### Algorithm and Kernel Updates

* The core subset selection now uses the `GreedyKernelPoints` solver with a `LinearKernel` instead of the previous `KernelHerding` solver with a `SquaredExponentialKernel`, improving selection efficiency and diversity. [[1]](diffhunk://#diff-bd9472afb5f4d1443584cbefe22523bc9c5581daa1ef19f08067fdcb0159e6e3L851-R857) [[2]](diffhunk://#diff-bd9472afb5f4d1443584cbefe22523bc9c5581daa1ef19f08067fdcb0159e6e3L862-R877)
* Updated the documentation in `_coresubset_selection` to reflect the new solver and kernel being used.

### Reproducibility and Configuration

* Added a `seed` parameter to the `GoldSelector` initializer, allowing users to set a random seed for reproducible selection results; this is now stored as `self.seed` and documented in the constructor docstring. [[1]](diffhunk://#diff-bd9472afb5f4d1443584cbefe22523bc9c5581daa1ef19f08067fdcb0159e6e3R100) [[2]](diffhunk://#diff-bd9472afb5f4d1443584cbefe22523bc9c5581daa1ef19f08067fdcb0159e6e3R120) [[3]](diffhunk://#diff-bd9472afb5f4d1443584cbefe22523bc9c5581daa1ef19f08067fdcb0159e6e3R137)

### Dependency and Import Changes

* Updated imports to include `jax`, `numpy`, and relevant classes from `coreax` for the new selection approach, while removing unused kernel and solver imports.