### PR TITLE
Update the selection table in order to flag new idx vector as already selected if their idx is already selected

### DIFF
--- a/goldener/select.py
+++ b/goldener/select.py
@@ -396,10 +396,21 @@ class GoldSelector:
         if select_count == 0 and isinstance(select_size, float):
             select_count = 1  # at least one sample
 
-        if (
-            len(self.get_selection_indices(selection_table, value, self.selection_key))
-            == select_count
-        ):
+        selection_indices = self.get_selection_indices(
+            selection_table, value, self.selection_key
+        )
+        if len(selection_indices) > 0:
+            # if new vectors have been added to the selection table
+            # make sure already selected samples are already flagged out
+            set_value_to_idx_rows(
+                table=selection_table,
+                col_expr=get_expr_from_column_name(selection_table, self.selection_key),
+                idx_expr=selection_table.idx,
+                indices=selection_indices,
+                value=value,
+            )
+
+        if len(selection_indices) == select_count:
             logger.info(
                 f"Selection table already fully filled out for {value} from {self.table_path}"
             )

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -188,6 +188,48 @@ class TestGoldSelector:
 
         pxt.drop_dir("unit_test", force=True)
 
+    def test_select_in_table_with_new_idx_vector(self):
+        pxt.drop_dir("unit_test", force=True)
+
+        table_path = "unit_test.test_select_from_dataset"
+
+        dataset = DummyDataset(
+            [
+                {"vectorized": torch.rand(5), "idx": idx, "idx_vector": idx}
+                for idx in range(100)
+            ]
+        )
+
+        selector = GoldSelector(
+            table_path=table_path, allow_existing=True, batch_size=10, max_batches=None
+        )
+
+        selection_table = selector.select_in_table(
+            dataset, select_size=10, value="train"
+        )
+        selected_indices_1 = selector.get_selection_indices(
+            selection_table, "train", selector.selection_key
+        )
+        assert len(selected_indices_1) == 10
+
+        dataset = DummyDataset(
+            [
+                {"vectorized": torch.rand(5), "idx": idx, "idx_vector": 100 + idx}
+                for idx in range(100)
+            ]
+        )
+        selection_table = selector.select_in_table(
+            dataset, select_size=20, value="train"
+        )
+
+        selected_indices_2 = selector.get_selection_indices(
+            selection_table, "train", selector.selection_key
+        )
+        assert len(selected_indices_2) == 20
+        assert selected_indices_1.issubset(selected_indices_2)
+
+        pxt.drop_dir("unit_test", force=True)
+
     def test_select_in_table_with_wrong_size(self):
         pxt.drop_dir("unit_test", force=True)
 

--- a/uv.lock
+++ b/uv.lock
@@ -764,7 +764,7 @@ wheels = [
 
 [[package]]
 name = "goldener"
-version = "3.0.0"
+version = "3.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "coreax" },
@@ -4293,10 +4293,10 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/ea/304cf7afb744aa626fa9855245526484ee55aba610d9973a0521c552a843/torch-2.10.0-1-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:c37fc46eedd9175f9c81814cc47308f1b42cfe4987e532d4b423d23852f2bf63", size = 79411450, upload-time = "2026-02-06T17:37:35.75Z" },
-    { url = "https://files.pythonhosted.org/packages/25/d8/9e6b8e7df981a1e3ea3907fd5a74673e791da483e8c307f0b6ff012626d0/torch-2.10.0-1-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:f699f31a236a677b3118bc0a3ef3d89c0c29b5ec0b20f4c4bf0b110378487464", size = 79423460, upload-time = "2026-02-06T17:37:39.657Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/2f/0b295dd8d199ef71e6f176f576473d645d41357b7b8aa978cc6b042575df/torch-2.10.0-1-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:6abb224c2b6e9e27b592a1c0015c33a504b00a0e0938f1499f7f514e9b7bfb5c", size = 79498197, upload-time = "2026-02-06T17:37:27.627Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/1b/af5fccb50c341bd69dc016769503cb0857c1423fbe9343410dfeb65240f2/torch-2.10.0-1-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:7350f6652dfd761f11f9ecb590bfe95b573e2961f7a242eccb3c8e78348d26fe", size = 79498248, upload-time = "2026-02-06T17:37:31.982Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/30/bfebdd8ec77db9a79775121789992d6b3b75ee5494971294d7b4b7c999bc/torch-2.10.0-2-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:2b980edd8d7c0a68c4e951ee1856334a43193f98730d97408fbd148c1a933313", size = 79411457, upload-time = "2026-02-10T21:44:59.189Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/8b/4b61d6e13f7108f36910df9ab4b58fd389cc2520d54d81b88660804aad99/torch-2.10.0-2-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:418997cb02d0a0f1497cf6a09f63166f9f5df9f3e16c8a716ab76a72127c714f", size = 79423467, upload-time = "2026-02-10T21:44:48.711Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/54/a2ba279afcca44bbd320d4e73675b282fcee3d81400ea1b53934efca6462/torch-2.10.0-2-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:13ec4add8c3faaed8d13e0574f5cd4a323c11655546f91fbe6afa77b57423574", size = 79498202, upload-time = "2026-02-10T21:44:52.603Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/23/2c9fe0c9c27f7f6cb865abcea8a4568f29f00acaeadfc6a37f6801f84cb4/torch-2.10.0-2-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:e521c9f030a3774ed770a9c011751fb47c4d12029a3d6522116e48431f2ff89e", size = 79498254, upload-time = "2026-02-10T21:44:44.095Z" },
     { url = "https://files.pythonhosted.org/packages/0c/1a/c61f36cfd446170ec27b3a4984f072fd06dab6b5d7ce27e11adb35d6c838/torch-2.10.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:5276fa790a666ee8becaffff8acb711922252521b28fbce5db7db5cf9cb2026d", size = 145992962, upload-time = "2026-01-21T16:24:14.04Z" },
     { url = "https://files.pythonhosted.org/packages/b5/60/6662535354191e2d1555296045b63e4279e5a9dbad49acf55a5d38655a39/torch-2.10.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:aaf663927bcd490ae971469a624c322202a2a1e68936eb952535ca4cd3b90444", size = 915599237, upload-time = "2026-01-21T16:23:25.497Z" },
     { url = "https://files.pythonhosted.org/packages/40/b8/66bbe96f0d79be2b5c697b2e0b187ed792a15c6c4b8904613454651db848/torch-2.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:a4be6a2a190b32ff5c8002a0977a25ea60e64f7ba46b1be37093c141d9c49aeb", size = 113720931, upload-time = "2026-01-21T16:24:23.743Z" },


### PR DESCRIPTION
This pull request improves the selection logic in the `select_in_table` method to better handle cases where new vectors are added to the selection table, ensuring that already selected samples are properly flagged. It also adds a new unit test to verify this updated behavior.

**Selection logic improvements:**

* Updated `select_in_table` in `goldener/select.py` to check if new vectors have been added to the selection table and ensure that already selected samples are flagged correctly. This prevents duplicate selection and maintains selection integrity.

**Testing enhancements:**

* Added a new test, `test_select_in_table_with_new_idx_vector`, in `tests/test_select.py` to verify that the selection logic correctly handles datasets with new index vectors and that previous selections are preserved.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes selection carry-over in select_in_table so already selected samples stay flagged when new idx_vector values appear. Prevents duplicate selection and keeps selection counts correct.

- **Bug Fixes**
  - When selection_indices exist, mark those idx rows as selected via set_value_to_idx_rows before checking completion.
  - Added test test_select_in_table_with_new_idx_vector to confirm prior selections persist and counts update when idx_vector changes.

- **Dependencies**
  - Bump goldener to 3.1.0 and update macOS torch wheels to 2.10.0-2 in uv.lock.

<sup>Written for commit 756375e843dc225a2995efa55c344025c295bcee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

