### PR TITLE
add GoldGreedyKCenterSelection to the init file of goldener

### DIFF
--- a/goldener/__init__.py
+++ b/goldener/__init__.py
@@ -27,6 +27,7 @@ from goldener.select import (
     GoldSelector,
     GoldGreedyClosestPointSelection,
     GoldGreedyFarthestPointSelection,
+    GoldGreedyKCenterSelection,
     GoldGreedyKernelPoints,
 )
 from goldener.split import GoldSet, GoldSplitter
@@ -60,6 +61,7 @@ __all__ = (
     "GoldSelector",
     "GoldGreedyClosestPointSelection",
     "GoldGreedyFarthestPointSelection",
+    "GoldGreedyKCenterSelection",
     "GoldGreedyKernelPoints",
     "GoldSet",
     "GoldSplitter",


### PR DESCRIPTION
This pull request adds a new selection strategy to the `goldener` package. The main change is the introduction of the `GoldGreedyKCenterSelection` class to the public API, making it available for import and use.

**New selection strategy:**

* Added `GoldGreedyKCenterSelection` to the list of importable classes in `goldener/__init__.py`, allowing users to access this selection strategy directly from the package. [[1]](diffhunk://#diff-c412e4a24253b9a90d1bf3261a9b3c1b7932b63c569b4f7fe29abcc5e0f2319aR30) [[2]](diffhunk://#diff-c412e4a24253b9a90d1bf3261a9b3c1b7932b63c569b4f7fe29abcc5e0f2319aR64)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes GoldGreedyKCenterSelection in the goldener public API by adding it to goldener/__init__.py. You can now import it directly: from goldener import GoldGreedyKCenterSelection.

<sup>Written for commit 2d554fc63844717520de3875effdb9e2ce79e966. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

