### PR TITLE
Remove useless var in GoldGreedyKCenterSelection

### DIFF
--- a/goldener/select.py
+++ b/goldener/select.py
@@ -169,7 +169,7 @@ class GoldGreedyKCenterSelection(GoldSelectionTool):
         # the next points are selected iteratively as the ones
         # with the largest distance to the already selected points
         distances = sample_to_sample_distance[first_idx]
-        for selection_idx in range(k - 1):
+        for _ in range(k - 1):
             next_idx = int(distances.argmax().item())
             selected_indices.append(next_idx)
 


### PR DESCRIPTION
This pull request makes a small update to the `select` function in `goldener/select.py`. The change refactors the loop variable name for clarity and consistency.

* Changed the loop variable from `selection_idx` to `_` in the `for` loop within the `select` function, since the variable was unused.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up the select loop in goldener/select.py by replacing an unused variable with `_`, improving clarity without changing behavior.

<sup>Written for commit 520171e9dfb44e844133d4ecb0f19ba46c8ba127. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

