### PR TITLE
Remove useless var in the other selection tools

### DIFF
--- a/goldener/select.py
+++ b/goldener/select.py
@@ -220,7 +220,7 @@ class GoldGreedyClosestPointSelection(GoldSelectionTool):
         selected_indices: list[int] = []
         remaining_indices = set(range(len(x)))
 
-        for selection_idx in range(k):
+        for _ in range(k):
             remaining_indices_as_list = list(remaining_indices)
             remaining_vectors = x[remaining_indices_as_list]
 
@@ -281,7 +281,7 @@ class GoldGreedyFarthestPointSelection(GoldSelectionTool):
         selected_indices: list[int] = []
         remaining_indices = set(range(len(x)))
 
-        for selection_idx in range(k):
+        for _ in range(k):
             remaining_indices_as_list = list(remaining_indices)
             remaining_vectors = x[remaining_indices_as_list]
 


### PR DESCRIPTION
This pull request makes a minor change to the `select` function in `goldener/select.py`, replacing the unused loop variable name `selection_idx` with `_` to indicate that the variable is not used in the loop.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the unused loop variable in select() with _ in two loops to clarify intent and silence linter warnings.
This is a no-op change that improves code readability in goldener/select.py.

<sup>Written for commit a293471628366ffec1d2421197d2cb6b9a087a9d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

