### PR TITLE
In GoldDescriptor, no need to specify the target when initializing the description column

### DIFF
--- a/goldener/describe.py
+++ b/goldener/describe.py
@@ -322,11 +322,6 @@ class GoldDescriptor:
                 description = (
                     self.vectorizer.vectorize(
                         torch.from_numpy(description).unsqueeze(0),
-                        (
-                            sample[self.target_key]
-                            if self.target_key in sample
-                            else None
-                        ),
                     )
                     .vectors[0]
                     .detach()
@@ -380,15 +375,9 @@ class GoldDescriptor:
                 .numpy()
             )
             if self.vectorizer is not None:
-                target = sample.get(self.target_key, None)
-                if target is not None and self.collate_fn is None:
-                    assert isinstance(target, torch.Tensor)
-                    target = target.unsqueeze(0)
-
                 description = (
                     self.vectorizer.vectorize(
                         torch.from_numpy(description).unsqueeze(0),
-                        target,
                     )
                     .vectors[0]
                     .detach()


### PR DESCRIPTION
This pull request simplifies the logic for handling the `target` argument in the vectorization process within the `goldener/describe.py` file. The main change is the removal of code that passes the `target` value to the vectorizer, streamlining the description generation workflow.

Refactoring vectorizer calls:

* Removed passing of the `target` argument to the `vectorizer.vectorize` method in both `_description_table_from_table` and `_description_table_from_dataset`, simplifying the function signatures and reducing conditional logic. [[1]](diffhunk://#diff-3329c3a1d40bcc6122b1c6d7b941f9f63d022dfb61e515c410ca465e1a6ee64dL325-L329) [[2]](diffhunk://#diff-3329c3a1d40bcc6122b1c6d7b941f9f63d022dfb61e515c410ca465e1a6ee64dL383-L391)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the need to pass a target to the vectorizer when initializing the description column in GoldDescriptor. This simplifies the description generation and removes target-specific conditionals and tensor handling.

- **Refactors**
  - Dropped the target argument from vectorizer.vectorize in _description_table_from_table and _description_table_from_dataset.
  - Removed target retrieval, assertion, and unsqueeze logic related to vectorizing descriptions.

<sup>Written for commit 5435d67e7bbe77e69c4a2c277ffa100723004928. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

