### PR TITLE
Make the class order constant when selecting from classes

### DIFF
--- a/goldener/pxt_utils.py
+++ b/goldener/pxt_utils.py
@@ -263,12 +263,14 @@ def get_distinct_value_and_count_in_column(
     Returns:
         A dictionary mapping distinct values to their counts in the specified column.
     """
-    return {
+    value_and_count = {
         distinct_item[col_expr.display_str()]: table.where(
             col_expr == distinct_item[col_expr.display_str()]
         ).count()
         for distinct_item in table.select(col_expr).distinct().collect()
     }
+
+    return dict(sorted(value_and_count.items()))
 
 
 def get_column_distinct_ratios(table: Table, col_expr: Expr) -> dict[str, float]:


### PR DESCRIPTION
This pull request makes a minor improvement to the `get_distinct_value_and_count_in_column` function in `goldener/pxt_utils.py`. The function now returns the dictionary of distinct values and their counts sorted by key, rather than in arbitrary order.

- Functionality improvement:
  * [`goldener/pxt_utils.py`](diffhunk://#diff-07a039edf0b3e142d59d88e7a6bd4eb8fa924ec332ed8a1d257387079960aa50L266-R274): Modified `get_distinct_value_and_count_in_column` to return a dictionary sorted by key for more predictable and readable output.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the output of get_distinct_value_and_count_in_column deterministic by sorting the returned dictionary by key. This ensures a stable class order when selecting from classes and produces more readable output.

<sup>Written for commit 2017a0f6f84a2ff14a95db0d145c82836caee25b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

