### PR TITLE
Complement the `Sampling among not annotated data` of the readme with the goal of the selected data

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ They are stored and available whenever a new request is made.
 ## Sampling among not annotated data
 
 Goldener can find the most representative data subset to annotate. It can extract and store semantic knowledge of the data
-from embeddings extracted with pre-trained models. Then, it leverages this knowledge to find the most representative subset of data to annotate.
+from embeddings extracted with pre-trained models. Then, it leverages this knowledge to find the most representative
+subset of data to annotate. This subset of data can be annotated in order to train or monitor a model.
 
 ```python
-
 from goldener import (
     GoldSelector,
     GoldDescriptor,
@@ -158,7 +158,6 @@ for cluster_id in range(10):
     # sample few samples and use them to define annotation guidelines for this cluster
 
 ```
-
 
 # Installation
 


### PR DESCRIPTION
This pull request makes minor improvements to the `README.md` documentation, clarifying the purpose of the representative data subset and cleaning up formatting.

- Documentation improvements:
  * Clarified that the representative data subset can be annotated to train or monitor a model, making the intended use of the subset more explicit.
  * Removed unnecessary blank lines to improve formatting in code examples.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies in README that the representative data subset can be annotated to train or monitor a model. Cleans up extra blank lines in code examples for readability.

<sup>Written for commit afb1d1897c966e3a04c8c683c78876c8d799054b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

