### PR TITLE
release-v6.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "goldener"
-version = "5.0.0"
+version = "6.0.0"
 description = "Goldener - Make your data even more valuable"
 readme = "README.md"
 license-files= ["LICENSE"]

--- a/uv.lock
+++ b/uv.lock
@@ -764,7 +764,7 @@ wheels = [
 
 [[package]]
 name = "goldener"
-version = "5.0.0"
+version = "6.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "coreax" },


### PR DESCRIPTION
This pull request updates the package version in `pyproject.toml` from 5.0.0 to 6.0.0.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the `goldener` package to version 6.0.0 to cut the v6 major release. Updates `pyproject.toml` and `uv.lock`; no code changes.

<sup>Written for commit c783709a40f6ad5a39e6606036415bdf861fbe90. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

