### PR TITLE
When selecting multiple labels start by selecting the label with the least number of elements

### DIFF
--- a/goldener/select.py
+++ b/goldener/select.py
@@ -1132,9 +1132,12 @@ class GoldSelector:
                     value=value,
                     force_all_labels=force_all_labels,
                 )
-                for label_idx, (label_value, label_count) in enumerate(
-                    selection_label_counts.items()
-                ):
+                # start with the labels with the lowest population in order to maximize the
+                # representativeness of the selection for all labels in multilabel tasks
+                selection_label_counts = dict(
+                    sorted(selection_label_counts.items(), key=lambda item: item[1])
+                )
+                for label_value, label_count in selection_label_counts.items():
                     if label_count == 0:
                         if force_all_labels:
                             raise ValueError(


### PR DESCRIPTION
This pull request updates the label selection logic in the `_sequential_select` function in `goldener/select.py` to improve the representativeness of selected samples, especially for multilabel tasks. The main change is to prioritize labels with the lowest population during selection.

**Selection logic improvement:**

* Modified the loop in `_sequential_select` to sort `selection_label_counts` so that labels with the fewest samples are considered first, maximizing representativeness for all labels in multilabel scenarios.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `_sequential_select` to start with labels that have the fewest samples when selecting across multiple labels. This improves balance and representativeness, especially for multilabel tasks.

<sup>Written for commit 44db9b22a64617c231785f6179fff864bc7ec4a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

