### PR TITLE
for the cosine distance, force the input to have the same channel number

### DIFF
--- a/goldener/distance.py
+++ b/goldener/distance.py
@@ -3,9 +3,20 @@ import torch.nn.functional as F
 
 
 def cosine_distance(x1: torch.Tensor, x2: torch.Tensor) -> torch.Tensor:
-    """Computes cosine distance between each pair of the two collections of row vectors."""
+    """Computes cosine distance between each pair of the two collections of row vectors.
+
+    Args:
+        x1: A tensor of shape (n, d) representing n vectors of dimension d.
+        x2: A tensor of shape (m, d) representing m vectors of dimension d.
+
+    Returns:
+        A tensor of shape (n, m) where the entry at (i, j) is the cosine distance between x1[i] and x2[j].
+    """
     if x1.ndim != 2 or x2.ndim != 2:
         raise ValueError("Input tensors must be 2D")
+
+    if x1.shape[1] != x2.shape[1]:
+        raise ValueError("Input tensors must have the same number of channels")
 
     x_norm = F.normalize(x1, p=2, dim=-1)
     y_norm = F.normalize(x2, p=2, dim=-1)

--- a/tests/test_distance.py
+++ b/tests/test_distance.py
@@ -45,3 +45,10 @@ class TestCosineDistance:
 
         with pytest.raises(ValueError, match="Input tensors must be 2D"):
             cosine_distance(x_2d, x_1d)
+
+    def test_inputs_must_same_dim(self) -> None:
+        x1 = torch.rand(2, 4)
+        x2 = torch.rand(3, 5)
+
+        with pytest.raises(ValueError, match="must have the same number of channels"):
+            cosine_distance(x1, x2)


### PR DESCRIPTION
This pull request improves input validation and documentation for the `cosine_distance` function in `goldener/distance.py`, and adds a new unit test to ensure correct error handling. The main changes are grouped below:

Input validation improvements:

* Added a check in `cosine_distance` to ensure input tensors have the same number of channels (second dimension), raising a `ValueError` if not.

Documentation updates:

* Expanded the docstring for `cosine_distance` to clarify input shapes, output shape, and behavior.

Testing enhancements:

* Added a new test `test_inputs_must_same_dim` in `tests/test_distance.py` to verify that a `ValueError` is raised when input tensors have different channel counts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces same channel dimension for inputs to cosine_distance and raises a ValueError on mismatch. Clarifies the docstring and adds a unit test to verify the new validation.

<sup>Written for commit 0c35600459c8897599a89b65b0fcb62b04d347f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

