### PR TITLE
Add logging info in the GoldSplitter and GoldSelector

### DIFF
--- a/goldener/select.py
+++ b/goldener/select.py
@@ -1546,8 +1546,8 @@ class GoldSelector:
                     current_selected_count -= already_selected_count  # remove the initial selection count to follow the current one
 
                 logger.info(
-                    f"Selected {current_selected_count - already_selected_count} samples "
-                    f"in the current chunk for value '{value}' and label '{label_value}'. "
+                    f"Selected {current_selected_count} samples "
+                    f"after the current chunk for value '{value}' and label '{label_value}'. "
                 )
 
             logger.info(

--- a/goldener/select.py
+++ b/goldener/select.py
@@ -1164,6 +1164,9 @@ class GoldSelector:
                 value,
                 self.selection_key,
             )
+            logger.info(
+                f"The selection value '{value}' has already {already_selected_count} samples"
+            )
 
             # The selection is done iteratively per label
             # The first labels might as well include the next labels in case of multi labels per sample
@@ -1187,6 +1190,9 @@ class GoldSelector:
                     if force_all_labels
                     else select_count
                     - already_selected_count  # otherwise, select only the remaining samples to select after counting the already selected ones for the label
+                )
+                logger.info(
+                    f"Selection loop per label with target count {loop_select_count} for value '{value}'"
                 )
                 # During the loop over the labels, the status of each label is computed and this values
                 # allows to define how many samples are still to select for the label
@@ -1241,6 +1247,11 @@ class GoldSelector:
                         - label_counts_init[label_value]
                     )
                     if label_count_status >= label_count:
+                        logger.info(
+                            f"Label '{label_value}' has already enough selected samples "
+                            f"for value '{value}' with {label_count_status} samples already selected, "
+                            f"skipping the label"
+                        )
                         continue
 
                     # select the missing ones based on the current status of the label
@@ -1349,6 +1360,10 @@ class GoldSelector:
             available_query = selection_col == None  # noqa: E711
 
         while current_selected_count < select_count:
+            logger.info(
+                f"Starting coresubset selection for value '{value}' and label '{label_value}'"
+                f" with target count {select_count} and already selected count {already_selected_count}"
+            )
             loop_start = (
                 current_selected_count  # validate some samples have been selected
             )
@@ -1369,7 +1384,17 @@ class GoldSelector:
                 break
 
             loop_select_count = select_count - current_selected_count
+            if loop_select_count != select_count:
+                logger.info(
+                    f"{current_selected_count} samples have already been selected for value '{value}' and label '{label_value}'. "
+                    f"Selecting the remaining {loop_select_count} samples to reach the target count {select_count}"
+                )
+
             if loop_select_count == still_selectable:
+                logger.info(
+                    f"Selecting all the remaining {still_selectable} samples for value"
+                    f" '{value}' and label '{label_value}' to reach the target count {select_count}"
+                )
                 set_value_to_idx_rows(
                     table=selection_table,
                     col_expr=selection_col,
@@ -1406,6 +1431,11 @@ class GoldSelector:
                 if chunk_select_count == 0:
                     continue
 
+                logger.info(
+                    f"Selecting {chunk_select_count} samples for value '{value}' and "
+                    f"label '{label_value}' from a chunk of {len(chunk_indices)} vectors"
+                )
+
                 # update the vector available for selection because the selection from previous chunks
                 # might have selected some of the samples in the current chunk, making them no longer
                 # available for selection in the current chunk
@@ -1419,6 +1449,10 @@ class GoldSelector:
                     .collect()
                 ]
                 if len(chunk_vector_indices_not_selected) == 0:
+                    logger.info(
+                        f"No more vector available for selection in the current "
+                        f"chunk for value '{value}' and label '{label_value}', skipping the chunk"
+                    )
                     continue
 
                 # load the vectors and the corresponding indices for the chunk
@@ -1507,8 +1541,19 @@ class GoldSelector:
                     label_key=self.label_key,
                     label_value=label_value,
                 )
+
                 if not from_already:
                     current_selected_count -= already_selected_count  # remove the initial selection count to follow the current one
+
+                logger.info(
+                    f"Selected {current_selected_count - already_selected_count} samples "
+                    f"in the current chunk for value '{value}' and label '{label_value}'. "
+                )
+
+            logger.info(
+                f"Selected {current_selected_count} samples in the current loop "
+                f"for value '{value}' and label '{label_value}'."
+            )
 
             if current_selected_count == loop_start:
                 raise ValueError(

--- a/goldener/select.py
+++ b/goldener/select.py
@@ -1641,6 +1641,11 @@ class GoldSelector:
                     f"Label '{label}' has no more selectable sample for value '{value}', but force_all_labels is True. "
                     f"This might be due to an issue in the selection process or the data."
                 )
+            else:
+                logger.info(
+                    f"Label '{label}' has no more selectable sample for value '{value}'. "
+                    f"This label will not be selected in the current selection loop."
+                )
 
         label_ratios = {
             value: ratio

--- a/goldener/split.py
+++ b/goldener/split.py
@@ -433,12 +433,13 @@ class GoldSplitter:
 
         # select data for all sets
         for idx_set, gold_set in enumerate(self._sets):
-            logger.info(
-                f"Selecting samples for set '{gold_set.name}' with size {gold_set.size}."
-            )
             set_count = get_sampling_count_from_size(
                 sampling_size=gold_set.size, total_size=sample_count
             )
+            logger.info(
+                f"Selecting samples for set '{gold_set.name}' with size {set_count} over {sample_count} samples."
+            )
+
             # the first sets are selected based on the specified ratios,
             # while the last one gathers all the remaining samples,
             # so we don't need to select it explicitly
@@ -451,6 +452,9 @@ class GoldSplitter:
                     )
                 )
             else:
+                logger.info(
+                    f"{gold_set.name} is the last set, all the remaining samples will be assigned to it."
+                )
                 # The last set is gathering all the remaining samples
                 selection_col = get_expr_from_column_name(
                     selected_table, self.selector.selection_key
@@ -485,6 +489,10 @@ class GoldSplitter:
         # or keep it in the selected table.
         split_table = selected_table
         if self.in_described_table:
+            logger.info(
+                "in_described_table is set to True, moving the selection column to the described table"
+                "and returning the described table as the final split table."
+            )
             if not isinstance(description, Table):
                 raise ValueError(
                     "in_described_table is set to True, but description is not a PixelTable Table."

--- a/goldener/split.py
+++ b/goldener/split.py
@@ -490,7 +490,7 @@ class GoldSplitter:
         split_table = selected_table
         if self.in_described_table:
             logger.info(
-                "in_described_table is set to True, moving the selection column to the described table"
+                "in_described_table is set to True, moving the selection column to the described table "
                 "and returning the described table as the final split table."
             )
             if not isinstance(description, Table):


### PR DESCRIPTION
This pull request adds extensive logging throughout the selection and splitting processes in the `goldener/select.py` and `goldener/split.py` modules. The added log messages provide detailed insights into the state and progress of selection loops, label handling, chunk processing, and set assignments, making it easier to debug and trace the execution flow during data selection and splitting.

**Logging improvements in selection logic:**

* Added log messages to `_sequential_select` in `goldener/select.py` to report when a selection value already has selected samples, the target count per label, and when a label has enough samples and is skipped. [[1]](diffhunk://#diff-bd9472afb5f4d1443584cbefe22523bc9c5581daa1ef19f08067fdcb0159e6e3R1167-R1169) [[2]](diffhunk://#diff-bd9472afb5f4d1443584cbefe22523bc9c5581daa1ef19f08067fdcb0159e6e3R1194-R1196) [[3]](diffhunk://#diff-bd9472afb5f4d1443584cbefe22523bc9c5581daa1ef19f08067fdcb0159e6e3R1250-R1254)
* Enhanced `_select_label` in `goldener/select.py` with logs indicating the start of selection for each value/label, progress updates when samples are already selected, details when all remaining samples are selected, and per-chunk selection actions and skips. [[1]](diffhunk://#diff-bd9472afb5f4d1443584cbefe22523bc9c5581daa1ef19f08067fdcb0159e6e3R1363-R1366) [[2]](diffhunk://#diff-bd9472afb5f4d1443584cbefe22523bc9c5581daa1ef19f08067fdcb0159e6e3R1387-R1397) [[3]](diffhunk://#diff-bd9472afb5f4d1443584cbefe22523bc9c5581daa1ef19f08067fdcb0159e6e3R1434-R1438) [[4]](diffhunk://#diff-bd9472afb5f4d1443584cbefe22523bc9c5581daa1ef19f08067fdcb0159e6e3R1452-R1455) [[5]](diffhunk://#diff-bd9472afb5f4d1443584cbefe22523bc9c5581daa1ef19f08067fdcb0159e6e3R1544-R1557)

**Logging improvements in dataset splitting:**

* Updated `split_in_table` in `goldener/split.py` to log the actual sample count for each set, indicate when the last set is assigned all remaining samples, and note when the selection column is moved to the described table. [[1]](diffhunk://#diff-d1c1f9e2375dc6c25aaa7b9fb1f5b90b718704fe94d4bdd77ee731abca240d92L436-R442) [[2]](diffhunk://#diff-d1c1f9e2375dc6c25aaa7b9fb1f5b90b718704fe94d4bdd77ee731abca240d92R455-R457) [[3]](diffhunk://#diff-d1c1f9e2375dc6c25aaa7b9fb1f5b90b718704fe94d4bdd77ee731abca240d92R492-R495)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds detailed info-level logging to selection and split flows to expose counts, per-label targets, chunk actions, set assignments, and when a label has no remaining selectable samples and is skipped. Improves traceability without changing behavior.

- **New Features**
  - `goldener/select.py`: `_sequential_select` and `_select_label` log existing selected counts, per-label target counts, skip reasons, start/progress per value/label, select-all-remaining paths, per-chunk selections and skips, after-chunk and per-iteration totals. `_compute_label_counts_for_selection` logs when a label has no more selectable samples for a value and will be skipped if not forcing all labels.
  - `goldener/split.py`: `split_in_table` logs per-set sample counts over the total, notes when the last set takes all remaining samples, and when the selection column is moved if `in_described_table` is True.

<sup>Written for commit c19d731d15c2e0f976a17c501f8dc6da579a207e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

