### PR TITLE
Add the possibility to merge the labels in case of multitargets

### DIFF
--- a/goldener/describe.py
+++ b/goldener/describe.py
@@ -61,6 +61,7 @@ class GoldDescriptor:
         target_to_label: Optional mapping from target values to label strings. Default is None.
         exclude_full_zero_target: Whether to exclude samples with a target tensor containing
             only zeros (in case of multi target). Default is False.
+        merge_multilabels: Whether to merge multiple labels into a single label. Default is False.
         exclude_labels: Optional set of label strings to exclude from vectorization. Default is None.
         description_key: Column name to store the computed embeddings in the PixelTable table. Default is "embeddings".
         force_fix_description: When True (default), the shape and dtype of the description are fixed in the
@@ -95,6 +96,7 @@ class GoldDescriptor:
         label_key: str | None = None,
         target_to_label: dict[tuple[int, ...], str] | None = None,
         exclude_full_zero_target: bool = False,
+        merge_multilabels: bool = False,
         exclude_labels: set[str] | None = None,
         description_key: str = "embeddings",
         force_fix_description: bool = True,
@@ -122,6 +124,7 @@ class GoldDescriptor:
             target_to_label: Optional mapping from target values to label strings. Default is None.
             exclude_full_zero_target: Whether to exclude samples with a target tensor containing
                 only zeros (in case of multi target). Default is False.
+            merge_multilabels: Whether to merge multiple labels into a single label. Default is False.
             exclude_labels: Optional set of label strings to exclude from vectorization. Default is None.
             description_key: Key for storing computed embeddings. Defaults to "embeddings".
             force_fix_description: When True (default), the shape and dtype of the description are fixed in
@@ -146,6 +149,7 @@ class GoldDescriptor:
         self.label_key = label_key
         self.target_to_label = target_to_label
         self.exclude_full_zero_target = exclude_full_zero_target
+        self.merge_multilabels = merge_multilabels
         self.exclude_labels = exclude_labels
         self.description_key = description_key
         self.force_fix_description = force_fix_description
@@ -576,6 +580,7 @@ class GoldDescriptor:
                     starts=start_idx,
                     label_key=self.label_key,
                     target_to_label=self.target_to_label,
+                    merge_multilabels=self.merge_multilabels,
                     exclude_full_zero_target=self.exclude_full_zero_target,
                     exclude_labels=self.exclude_labels,
                 )

--- a/goldener/utils.py
+++ b/goldener/utils.py
@@ -417,16 +417,16 @@ def transform_batch_from_multiple_to_binarized_targets(
 
         target_per_label[label] = new_target
 
+    if not target_per_label:
+        raise ValueError(
+            "No valid targets found after applying exclude_full_zero filter."
+        )
+
     if merge_labels:
         new_label = "_".join(sorted(target_per_label.keys()))
         target_per_label = {
             new_label: torch.stack(list(target_per_label.values()), dim=0).sum(dim=0)
         }
-
-    if not target_per_label:
-        raise ValueError(
-            "No valid targets found after applying exclude_full_zero filter."
-        )
 
     # duplicate the batch element for each label/target and
     # insert the corresponding binarized target/label in the batch alongside them.
@@ -471,8 +471,7 @@ def transform_batch_from_multilabel_to_independent_labels(
     """Transform a batch with multilabel into a batch with one entry per label.
 
     Args:
-        batch: A dictionary representing a batch of data, where the target key contains a multilabel target
-            with values corresponding to the labels in target_to_label.
+        batch: A dictionary representing a batch of data, where the label key contains several labels.
         label_key: The key in the batch dictionary that contains the labels.
         merge_labels: Whether to merge the labels into a single label (default: False).
             If False, the batch will be duplicated for each label.
@@ -504,7 +503,7 @@ def transform_batch_from_multilabel_to_independent_labels(
                 if exclude_labels is None or label not in exclude_labels
             ]
         )
-        if merge_labels:
+        if merge_labels and not_excluded_labels:
             not_excluded_labels = ["_".join(not_excluded_labels)]
 
         for label in not_excluded_labels:

--- a/goldener/utils.py
+++ b/goldener/utils.py
@@ -359,6 +359,7 @@ def transform_batch_from_multiple_to_binarized_targets(
     target_key: str,
     label_key: str | None,
     target_to_label: dict[tuple[int, ...], str],
+    merge_labels: bool = False,
     exclude_labels: set[str] | None = None,
     exclude_full_zero: bool = False,
 ) -> dict[str, Any]:
@@ -370,6 +371,7 @@ def transform_batch_from_multiple_to_binarized_targets(
         target_key: The key in the batch dictionary that contains the target.
         label_key: The key in the batch dictionary that containes the labels.
         target_to_label: A mapping from unique target tuples to label values.
+        merge_labels: Whether to merge the labels into a single label (default: False).
         exclude_labels: An optional set of labels to exclude from the transformation (default: None).
         exclude_full_zero: Whether to exclude the all-zero target from the transformation (default: False).
 
@@ -415,6 +417,12 @@ def transform_batch_from_multiple_to_binarized_targets(
 
         target_per_label[label] = new_target
 
+    if merge_labels:
+        new_label = "_".join(sorted(target_per_label.keys()))
+        target_per_label = {
+            new_label: torch.stack(list(target_per_label.values()), dim=0).sum(dim=0)
+        }
+
     if not target_per_label:
         raise ValueError(
             "No valid targets found after applying exclude_full_zero filter."
@@ -454,9 +462,10 @@ def transform_batch_from_multiple_to_binarized_targets(
     return new_batch
 
 
-def transform_batch_from_multilabel_to_binary_labels(
+def transform_batch_from_multilabel_to_independent_labels(
     batch: dict[str, torch.Tensor | list],
     label_key: str,
+    merge_labels: bool = False,
     exclude_labels: set[str] | None = None,
 ) -> dict[str, torch.Tensor | list]:
     """Transform a batch with multilabel into a batch with one entry per label.
@@ -465,10 +474,14 @@ def transform_batch_from_multilabel_to_binary_labels(
         batch: A dictionary representing a batch of data, where the target key contains a multilabel target
             with values corresponding to the labels in target_to_label.
         label_key: The key in the batch dictionary that contains the labels.
+        merge_labels: Whether to merge the labels into a single label (default: False).
+            If False, the batch will be duplicated for each label.
+            If True, the labels will be merged into a single label by concatenating
+            them with a separator (e.g., "_").
         exclude_labels: An optional set of labels to exclude from the transformation (default: None).
 
     Returns:
-        A new batch dictionary where samples with multiple labels are duplicated for each label.
+        A new batch dictionary where samples with multiple labels are split/merge in single entries.
     """
     # duplicate the batch element for each label and
     # insert the corresponding label in the batch alongside them.
@@ -483,10 +496,18 @@ def transform_batch_from_multilabel_to_binary_labels(
         sample = {
             key: value[sample_idx] for key, value in batch.items() if key != label_key
         }
-        for label in labels:
-            if exclude_labels is not None and label in exclude_labels:
-                continue
 
+        not_excluded_labels = sorted(
+            [
+                label
+                for label in labels
+                if exclude_labels is None or label not in exclude_labels
+            ]
+        )
+        if merge_labels:
+            not_excluded_labels = ["_".join(not_excluded_labels)]
+
+        for label in not_excluded_labels:
             sample[label_key] = label
             for key, value in sample.items():
                 new_batch_as_lists[key].append(value)

--- a/goldener/vectorize.py
+++ b/goldener/vectorize.py
@@ -1028,8 +1028,7 @@ def vectorize_and_unwrap_in_batch(
         target_key: Optional key in the batch dictionary containing the target used to filter vectors.
         label_key: Optional key in the batch dictionary containing the labels.
         target_to_label: Optional mapping from target values to labels for binarization.
-        merge_multilabels: Whether to merge multiple labels into a single label
-            string when target_to_label is used. Default is False.
+        merge_multilabels: Whether to merge multiple labels into a single label. Default is False.
         exclude_labels: Optional set of label strings to exclude from vectorization. Default is None.
         to_keep: Optional list of additional keys to preserve from the batch.
         starts: Starting index for assigning new `idx_vector` values.

--- a/goldener/vectorize.py
+++ b/goldener/vectorize.py
@@ -1010,6 +1010,7 @@ def vectorize_and_unwrap_in_batch(
     target_key: str | None = None,
     label_key: str | None = None,
     target_to_label: dict[tuple[int, ...], str] | None = None,
+    merge_multilabels: bool = False,
     exclude_labels: set[str] | None = None,
     to_keep: list[str] | None = None,
     starts: int = 0,
@@ -1028,6 +1029,8 @@ def vectorize_and_unwrap_in_batch(
         target_key: Optional key in the batch dictionary containing the target used to filter vectors.
         label_key: Optional key in the batch dictionary containing the labels.
         target_to_label: Optional mapping from target values to labels for binarization.
+        merge_multilabels: Whether to merge multiple labels into a single label
+            string when target_to_label is used. Default is False.
         exclude_labels: Optional set of label strings to exclude from vectorization. Default is None.
         to_keep: Optional list of additional keys to preserve from the batch.
         starts: Starting index for assigning new `idx_vector` values.

--- a/goldener/vectorize.py
+++ b/goldener/vectorize.py
@@ -454,6 +454,8 @@ class GoldVectorizer:
         vectorized_key: Column name to store the resulting vectors in the PixelTable table. Default is "vectorized".
         label_key: Optional key for labels in the batch dictionary. Default is None.
         target_to_label: Optional mapping from target values to label strings. Default is None.
+        merge_multilabels: Whether to merge multiple labels into a single label
+            string when target_to_label is used. Default is False.
         exclude_full_zero_target: Whether to exclude samples with a target tensor containing
             only zeros (in case of multi target). Default is False.
         exclude_labels: Optional set of label strings to exclude from vectorization. Default is None.
@@ -484,6 +486,7 @@ class GoldVectorizer:
         vectorized_key: str = "vectorized",
         label_key: str | None = None,
         target_to_label: dict[tuple[int, ...], str] | None = None,
+        merge_multilabels: bool = False,
         exclude_labels: set[str] | None = None,
         exclude_full_zero_target: bool = False,
         to_keep_schema: dict[str, type] | None = None,
@@ -506,6 +509,8 @@ class GoldVectorizer:
             vectorized_key: Column name for storing vectors. Defaults to "vectorized".
             label_key: Optional key for labels in the batch dictionary. Default is None.
             target_to_label: Optional mapping from target values to label strings. Default is None.
+            merge_multilabels: Whether to merge multiple labels into a single label
+                string when target_to_label is used. Default is False.
             exclude_labels: Optional set of label strings to exclude from vectorization. Default is None.
             exclude_full_zero_target: Whether to exclude samples with a target tensor containing
                 only zeros (in case of multi target). Default is False.
@@ -527,6 +532,7 @@ class GoldVectorizer:
         self.target_to_label = target_to_label
         self.exclude_labels = exclude_labels
         self.exclude_full_zero_target = exclude_full_zero_target
+        self.merge_multilabels = merge_multilabels
         self.vectorized_key = vectorized_key
         self.to_keep_schema = to_keep_schema
         self.min_pxt_insert_size = min_pxt_insert_size

--- a/goldener/vectorize.py
+++ b/goldener/vectorize.py
@@ -32,7 +32,7 @@ from goldener.utils import (
     check_x_and_y_shapes,
     filter_batch_from_indices,
     transform_batch_from_multiple_to_binarized_targets,
-    transform_batch_from_multilabel_to_binary_labels,
+    transform_batch_from_multilabel_to_independent_labels,
 )
 
 logger = getLogger(__name__)
@@ -454,8 +454,7 @@ class GoldVectorizer:
         vectorized_key: Column name to store the resulting vectors in the PixelTable table. Default is "vectorized".
         label_key: Optional key for labels in the batch dictionary. Default is None.
         target_to_label: Optional mapping from target values to label strings. Default is None.
-        merge_multilabels: Whether to merge multiple labels into a single label
-            string when target_to_label is used. Default is False.
+        merge_multilabels: Whether to merge multiple labels into a single label. Default is False.
         exclude_full_zero_target: Whether to exclude samples with a target tensor containing
             only zeros (in case of multi target). Default is False.
         exclude_labels: Optional set of label strings to exclude from vectorization. Default is None.
@@ -509,8 +508,7 @@ class GoldVectorizer:
             vectorized_key: Column name for storing vectors. Defaults to "vectorized".
             label_key: Optional key for labels in the batch dictionary. Default is None.
             target_to_label: Optional mapping from target values to label strings. Default is None.
-            merge_multilabels: Whether to merge multiple labels into a single label
-                string when target_to_label is used. Default is False.
+            merge_multilabels: Whether to merge multiple labels into a single label. Default is False.
             exclude_labels: Optional set of label strings to exclude from vectorization. Default is None.
             exclude_full_zero_target: Whether to exclude samples with a target tensor containing
                 only zeros (in case of multi target). Default is False.
@@ -901,6 +899,7 @@ class GoldVectorizer:
                 to_keep=to_keep_keys,
                 starts=start_idx,
                 target_to_label=self.target_to_label,
+                merge_multilabels=self.merge_multilabels,
                 label_key=self.label_key,
                 exclude_full_zero_target=self.exclude_full_zero_target,
                 exclude_labels=self.exclude_labels,
@@ -1042,9 +1041,10 @@ def vectorize_and_unwrap_in_batch(
     if target_key is None or target_key not in batch:
         target = None
         if label_key is not None and label_key in batch:
-            batch = transform_batch_from_multilabel_to_binary_labels(
+            batch = transform_batch_from_multilabel_to_independent_labels(
                 batch=batch,
                 label_key=label_key,
+                merge_labels=merge_multilabels,
                 exclude_labels=exclude_labels,
             )
 
@@ -1057,6 +1057,7 @@ def vectorize_and_unwrap_in_batch(
                 target_key=target_key,
                 label_key=label_key,
                 target_to_label=target_to_label,
+                merge_labels=merge_multilabels,
                 exclude_full_zero=exclude_full_zero_target,
                 exclude_labels=exclude_labels,
             )

--- a/tests/test_describe.py
+++ b/tests/test_describe.py
@@ -1,3 +1,6 @@
+from collections import defaultdict
+
+import numpy as np
 import pytest
 import torch
 
@@ -569,35 +572,158 @@ class TestGoldDescriptor:
         target = torch.zeros(1, 8, 8).numpy()
         target[0, 0, 0] = 25
 
-        source_rows = [
-            {
-                "idx": 0,
-                "data": torch.zeros(3, 8, 8).numpy(),
-                "label": [
-                    "class_1",
-                ],
-                "target": target,
+        pxt.create_dir("unit_test", if_exists="ignore")
+        src_table = pxt.create_table(
+            src_path,
+            schema={
+                "idx": pxt.Int,
+                "data": pxt.Array[(3, 8, 8), np.float32],
+                "label": pxt.Json,
+                "target": pxt.Array[(1, 8, 8), np.float32],
             },
-            {
-                "idx": 1,
-                "data": torch.zeros(3, 8, 8).numpy(),
-                "label": [
-                    "class_1",
-                ],
-                "target": target,
-            },
-        ]
+            if_exists="replace_force",
+        )
+
+        src_table.insert(
+            [
+                {
+                    "idx": 0,
+                    "data": torch.zeros(3, 8, 8).numpy(),
+                    "label": [
+                        "class_1",
+                        "class_2",
+                    ],
+                    "target": target,
+                },
+                {
+                    "idx": 1,
+                    "data": torch.zeros(3, 8, 8).numpy(),
+                    "label": [
+                        "class_1",
+                        "class_2",
+                    ],
+                    "target": target,
+                },
+            ]
+        )
+
+        def collate_fn(batch: list[dict]):
+            new_batch_as_list = defaultdict(list)
+
+            for sample in batch:
+                new_batch_as_list["idx"].append(sample["idx"])
+                new_batch_as_list["label"].append(sample["label"])
+                new_batch_as_list["target"].append(sample["target"])
+                new_batch_as_list["data"].append(sample["data"])
+
+            return {
+                "data": torch.stack(
+                    [torch.from_numpy(d) for d in new_batch_as_list["data"]], dim=0
+                ),
+                "target": torch.stack(
+                    [torch.from_numpy(t) for t in new_batch_as_list["target"]], dim=0
+                ),
+                "idx": new_batch_as_list["idx"],
+                "label": new_batch_as_list["label"],
+            }
+
+        desc = GoldDescriptor(
+            table_path="unit_test.test_describe",
+            embedder=embedder,
+            vectorizer=vectorizer,
+            label_key="label",
+            to_keep_schema={"label": pxt.String},
+            target_to_label={(25,): "class_1", (0,): "class_2"},
+            batch_size=2,
+            collate_fn=collate_fn,
+            device=torch.device("cpu"),
+            allow_existing=False,
+            drop_table=True,
+        )
+
+        description = desc.describe_in_table(src_table)
+
+        assert description.count() == 128
+        for row in description.collect():
+            assert row["idx"] in (0, 1)
+            assert row["embeddings"].shape == (4,)
+            assert row["label"] in ("class_1", "class_2")
+
+        pxt.drop_dir("unit_test", force=True)
+
+    def test_describe_in_dataset_from_table_with_vectorizer_and_merge_multilabel(
+        self, embedder, vectorizer
+    ):
+        pxt.drop_dir("unit_test", force=True)
+
+        src_path = "unit_test.src_table_input"
+
+        target = torch.zeros(1, 8, 8).numpy()
+        target[0, 0, 0] = 25
 
         pxt.create_dir("unit_test", if_exists="ignore")
         src_table = pxt.create_table(
-            src_path, source=source_rows, if_exists="replace_force"
+            src_path,
+            schema={
+                "idx": pxt.Int,
+                "data": pxt.Array[(3, 8, 8), np.float32],
+                "label": pxt.Json,
+                "target": pxt.Array[(1, 8, 8), np.float32],
+            },
+            if_exists="replace_force",
         )
+
+        src_table.insert(
+            [
+                {
+                    "idx": 0,
+                    "data": torch.zeros(3, 8, 8).numpy(),
+                    "label": [
+                        "class_1",
+                        "class_2",
+                    ],
+                    "target": target,
+                },
+                {
+                    "idx": 1,
+                    "data": torch.zeros(3, 8, 8).numpy(),
+                    "label": [
+                        "class_1",
+                        "class_2",
+                    ],
+                    "target": target,
+                },
+            ]
+        )
+
+        def collate_fn(batch: list[dict]):
+            new_batch_as_list = defaultdict(list)
+
+            for sample in batch:
+                new_batch_as_list["idx"].append(sample["idx"])
+                new_batch_as_list["label"].append(sample["label"])
+                new_batch_as_list["target"].append(sample["target"])
+                new_batch_as_list["data"].append(sample["data"])
+
+            return {
+                "data": torch.stack(
+                    [torch.from_numpy(d) for d in new_batch_as_list["data"]], dim=0
+                ),
+                "target": torch.stack(
+                    [torch.from_numpy(t) for t in new_batch_as_list["target"]], dim=0
+                ),
+                "idx": new_batch_as_list["idx"],
+                "label": new_batch_as_list["label"],
+            }
 
         desc = GoldDescriptor(
             table_path="unit_test.test_describe",
             embedder=embedder,
             vectorizer=vectorizer,
             target_to_label={(25,): "class_1", (0,): "class_2"},
+            label_key="label",
+            merge_multilabels=True,
+            to_keep_schema={"label": pxt.String},
             batch_size=2,
             collate_fn=None,
             device=torch.device("cpu"),
@@ -611,6 +737,7 @@ class TestGoldDescriptor:
         for row in description.collect():
             assert row["idx"] in (0, 1)
             assert row["embeddings"].shape == (4,)
+            assert row["label"] == "class_1_class_2"
 
         pxt.drop_dir("unit_test", force=True)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,7 +13,7 @@ from goldener.utils import (
     split_sampling_among_chunks,
     transform_batch_from_multiple_to_binarized_targets,
     get_sampling_count_from_ratios,
-    transform_batch_from_multilabel_to_binary_labels,
+    transform_batch_from_multilabel_to_independent_labels,
 )
 
 
@@ -493,6 +493,39 @@ class TestTransformBatchFromMultipleToBinarizedTargets:
         assert (out["target"] == new_target).all()
         assert out["label"] == ["A", "A", "B", "B"]
 
+    def test_with_merge_multilabel(self):
+        target = torch.zeros(2, 2)
+        target[0, 0] = 25
+        data = torch.arange(6).reshape(2, 3)
+        batch = {
+            "data": data,
+            "target": target,
+            "label": [
+                {"A", "B"},
+                {
+                    "B",
+                },
+            ],
+        }
+
+        target_to_label = {
+            (0, 0): "A",
+            (25, 0): "B",
+        }
+
+        out = transform_batch_from_multiple_to_binarized_targets(
+            batch=batch,
+            target_key="target",
+            label_key="label",
+            target_to_label=target_to_label,
+            merge_labels=True,
+        )
+
+        assert (out["data"] == data).all()
+        new_target = torch.ones(2, 1)
+        assert (out["target"] == new_target).all()
+        assert out["label"] == ["A_B", "A_B"]
+
     def test_with_exclude_zero(self):
         target = torch.zeros(2, 1)
         target[0, 0] = 25
@@ -684,7 +717,7 @@ class TestTransformBatchFromMultilabelToBinaryLabels:
             "label": ["a", "b"],
         }
 
-        out = transform_batch_from_multilabel_to_binary_labels(
+        out = transform_batch_from_multilabel_to_independent_labels(
             batch=batch,
             label_key="label",
         )
@@ -706,7 +739,7 @@ class TestTransformBatchFromMultilabelToBinaryLabels:
             ],
         }
 
-        out = transform_batch_from_multilabel_to_binary_labels(
+        out = transform_batch_from_multilabel_to_independent_labels(
             batch=batch,
             label_key="label",
         )
@@ -716,6 +749,35 @@ class TestTransformBatchFromMultilabelToBinaryLabels:
         assert isinstance(x_out, torch.Tensor)
         assert torch.equal(x_out, expected_x)
         expected_labels = sorted(["a", "b", "b", "c", "a"])
+        assert sorted(out["label"]) == expected_labels
+
+    def test_with_merge_labels(self) -> None:
+        x = torch.arange(6).reshape(3, 2)
+        batch: dict[str, torch.Tensor | list] = {
+            "x": x,
+            "label": [
+                {"a", "b"},
+                {"b"},
+                {"c", "a"},
+            ],
+        }
+
+        out = transform_batch_from_multilabel_to_independent_labels(
+            batch=batch,
+            label_key="label",
+            merge_labels=True,
+        )
+
+        x_out = out["x"]
+        assert isinstance(x_out, torch.Tensor)
+        assert torch.equal(x_out, x)
+        expected_labels = sorted(
+            [
+                "a_b",
+                "a_c",
+                "b",
+            ]
+        )
         assert sorted(out["label"]) == expected_labels
 
     def test_exclude_labels(self) -> None:
@@ -730,7 +792,7 @@ class TestTransformBatchFromMultilabelToBinaryLabels:
             "other": ["keep1", "keep2", "keep3"],
         }
 
-        out = transform_batch_from_multilabel_to_binary_labels(
+        out = transform_batch_from_multilabel_to_independent_labels(
             batch=batch,
             label_key="label",
             exclude_labels={"b"},

--- a/tests/test_vectorize.py
+++ b/tests/test_vectorize.py
@@ -551,6 +551,60 @@ class TestGoldVectorizer:
 
         pxt.drop_dir("unit_test", force=True)
 
+    def test_vectorize_in_table_with_multitarget_and_merge_multilabels(self):
+        pxt.drop_dir("unit_test", force=True)
+
+        src_path = "unit_test.src_table_vectorize"
+        desc_path = "unit_test.vectorize_from_table"
+
+        target = torch.zeros(2, 3)
+        target[:, 0] = torch.tensor([25, 25])
+        target = target.numpy()
+
+        source_rows = [
+            {
+                "idx": 0,
+                "embeddings": torch.zeros(4, 3).numpy(),
+                "label": list({"class_0", "class_1"}),
+                "target": target,
+            },
+            {
+                "idx": 1,
+                "embeddings": torch.zeros(4, 3).numpy(),
+                "label": list({"class_0", "class_1"}),
+                "target": target,
+            },
+        ]
+
+        pxt.create_dir("unit_test", if_exists="ignore")
+        src_table = pxt.create_table(
+            src_path, source=source_rows, if_exists="replace_force"
+        )
+
+        gv = GoldVectorizer(
+            table_path=desc_path,
+            vectorizer=TensorVectorizer(),
+            collate_fn=None,
+            data_key="embeddings",
+            vectorized_key="vectorized",
+            merge_multilabels=True,
+            to_keep_schema={"label": pxt.String},
+            batch_size=1,
+            num_workers=0,
+            allow_existing=False,
+            target_to_label={(0, 0): "class_0", (25, 25): "class_1"},
+            label_key="label",
+            exclude_full_zero_target=False,
+        )
+
+        out_table = gv.vectorize_in_table(src_table)
+        assert out_table.count() == 3 * 2
+        for row_idx, row in enumerate(out_table.collect()):
+            assert row["vectorized"].shape == (4,)
+            assert row["label"] == "class_0_class_1"
+
+        pxt.drop_dir("unit_test", force=True)
+
     def test_vectorize_in_table_with_multitarget_and_zero_excluded(self):
         pxt.drop_dir("unit_test", force=True)
 


### PR DESCRIPTION
This pull request adds support for merging multiple labels into a single label in the `GoldDescriptor` and `GoldVectorizer` workflows, allowing for more flexible handling of multi-label data during vectorization and description. It introduces new parameters and logic to control label merging, updates relevant transformation utilities, and expands test coverage to verify the new behavior.

**Enhancements to multi-label handling:**

* Added a `merge_multilabels` parameter to `GoldDescriptor` and `GoldVectorizer`, along with corresponding docstring updates and internal assignments, to enable merging multiple labels into a single label string during processing. [[1]](diffhunk://#diff-3329c3a1d40bcc6122b1c6d7b941f9f63d022dfb61e515c410ca465e1a6ee64dR64) [[2]](diffhunk://#diff-3329c3a1d40bcc6122b1c6d7b941f9f63d022dfb61e515c410ca465e1a6ee64dR99) [[3]](diffhunk://#diff-3329c3a1d40bcc6122b1c6d7b941f9f63d022dfb61e515c410ca465e1a6ee64dR127) [[4]](diffhunk://#diff-3329c3a1d40bcc6122b1c6d7b941f9f63d022dfb61e515c410ca465e1a6ee64dR152) [[5]](diffhunk://#diff-1cf6a39f1b4d91d02e9b16ee59314e625b9a5adcd0c44be3d3a7009dc250efc6R457) [[6]](diffhunk://#diff-1cf6a39f1b4d91d02e9b16ee59314e625b9a5adcd0c44be3d3a7009dc250efc6R488) [[7]](diffhunk://#diff-1cf6a39f1b4d91d02e9b16ee59314e625b9a5adcd0c44be3d3a7009dc250efc6R511) [[8]](diffhunk://#diff-1cf6a39f1b4d91d02e9b16ee59314e625b9a5adcd0c44be3d3a7009dc250efc6R533)
* Updated internal batch transformation logic in `goldener/utils.py` to support label merging, including changes to `transform_batch_from_multiple_to_binarized_targets` and renaming `transform_batch_from_multilabel_to_binary_labels` to `transform_batch_from_multilabel_to_independent_labels`, with new logic for merging labels when requested. [[1]](diffhunk://#diff-996a5e6a5c57e8a2806d8f5753ec8c8184cbf9766795fbafcc066c436f5af595R362) [[2]](diffhunk://#diff-996a5e6a5c57e8a2806d8f5753ec8c8184cbf9766795fbafcc066c436f5af595R374) [[3]](diffhunk://#diff-996a5e6a5c57e8a2806d8f5753ec8c8184cbf9766795fbafcc066c436f5af595R420-R425) [[4]](diffhunk://#diff-996a5e6a5c57e8a2806d8f5753ec8c8184cbf9766795fbafcc066c436f5af595L457-R468) [[5]](diffhunk://#diff-996a5e6a5c57e8a2806d8f5753ec8c8184cbf9766795fbafcc066c436f5af595R477-R484) [[6]](diffhunk://#diff-996a5e6a5c57e8a2806d8f5753ec8c8184cbf9766795fbafcc066c436f5af595L486-R510) [[7]](diffhunk://#diff-1cf6a39f1b4d91d02e9b16ee59314e625b9a5adcd0c44be3d3a7009dc250efc6L35-R35)
* Propagated the `merge_multilabels` parameter through all relevant code paths, including batch vectorization and sequential describe/vectorize functions. [[1]](diffhunk://#diff-3329c3a1d40bcc6122b1c6d7b941f9f63d022dfb61e515c410ca465e1a6ee64dR583) [[2]](diffhunk://#diff-1cf6a39f1b4d91d02e9b16ee59314e625b9a5adcd0c44be3d3a7009dc250efc6R902) [[3]](diffhunk://#diff-1cf6a39f1b4d91d02e9b16ee59314e625b9a5adcd0c44be3d3a7009dc250efc6R1012) [[4]](diffhunk://#diff-1cf6a39f1b4d91d02e9b16ee59314e625b9a5adcd0c44be3d3a7009dc250efc6R1031-R1032) [[5]](diffhunk://#diff-1cf6a39f1b4d91d02e9b16ee59314e625b9a5adcd0c44be3d3a7009dc250efc6L1036-R1047) [[6]](diffhunk://#diff-1cf6a39f1b4d91d02e9b16ee59314e625b9a5adcd0c44be3d3a7009dc250efc6R1060)

**Testing improvements:**

* Added a new test (`test_describe_in_dataset_from_table_with_vectorizer_and_merge_multilabel`) to verify correct behavior when merging multi-labels, and refactored existing tests to use a more robust table setup and batch collation. [[1]](diffhunk://#diff-e13a452bb87733f24d24eb2c58094f187608a96287b06841e4db57c831aac390R1-R3) [[2]](diffhunk://#diff-e13a452bb87733f24d24eb2c58094f187608a96287b06841e4db57c831aac390L572-R594) [[3]](diffhunk://#diff-e13a452bb87733f24d24eb2c58094f187608a96287b06841e4db57c831aac390R603-R726) [[4]](diffhunk://#diff-e13a452bb87733f24d24eb2c58094f187608a96287b06841e4db57c831aac390R740)

These changes improve the flexibility and usability of the multi-label data processing pipeline, making it easier to handle datasets where samples may have multiple associated labels.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an option to merge multi-label sets into a single label across descriptor and vectorizer workflows. This lets you treat label sets as one class and simplifies downstream processing.

- **New Features**
  - Added merge_multilabels to GoldDescriptor and GoldVectorizer (default: false).
  - Batch utils support merging:
    - transform_batch_from_multiple_to_binarized_targets(..., merge_labels=True) joins labels (sorted, "_") and sums targets.
    - transform_batch_from_multilabel_to_independent_labels(..., merge_labels=True) merges labels when no target is used.
  - merge_multilabels is propagated through vectorize_and_unwrap_in_batch and sequential describe/vectorize paths.
  - Tests cover merging in multitarget and multilabel flows, exclude_labels handling, and label persistence.

- **Migration**
  - Rename utils.transform_batch_from_multilabel_to_binary_labels to transform_batch_from_multilabel_to_independent_labels and update calls (optional merge_labels parameter).

<sup>Written for commit d735cf352e76d2b65be96e4a6375dc2b3573cf72. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

