### PR TITLE
In the GoldSelector, starts by selecting every labels with the specified selection ratio

### DIFF
--- a/goldener/select.py
+++ b/goldener/select.py
@@ -882,14 +882,19 @@ class GoldSelector:
         assert isinstance(select_from, Table)
 
         # define the number of element to sample
-        total_size = select_from.select(select_from.idx).distinct().count()
+        total_size = selection_table.select(selection_table.idx).distinct().count()
+        if total_size == 0:
+            raise ValueError("The selection table is empty.")
+        if isinstance(select_size, int) and select_size > total_size:
+            raise ValueError(
+                f"select_size {select_size} cannot be greater than the total number of samples {total_size}."
+            )
+
         select_count = (
             select_size
             if isinstance(select_size, int)
-            else int(select_size * total_size)
+            else math.ceil(select_size * total_size)  # at least one sample
         )
-        if select_count == 0 and isinstance(select_size, float):
-            select_count = 1  # at least one sample
 
         select_ratio = (
             select_size if isinstance(select_size, float) else select_size / total_size
@@ -1898,11 +1903,11 @@ class GoldSelector:
         }
 
         # The selection count for each label is first obtained from
-        # the flooring of the multiplication of the label count by the selection ratio
-        # then the label with 0 selected sampled are forced to be not 0
-        # by taking samples from the bigger labels
+        # flooring the multiplication of the label count by the selection ratio.
+        # Then, labels with 0 selected samples are forced to have a non-zero
+        # selection count by taking samples from the bigger labels.
         label_select_count = {
-            label: math.floor(count * select_ratio) if count > 0 else 0
+            label: math.floor(count * select_ratio)
             for label, count in label_counts.items()
         }
 

--- a/goldener/select.py
+++ b/goldener/select.py
@@ -1,3 +1,4 @@
+import math
 from abc import ABC, abstractmethod
 from enum import Enum
 from logging import getLogger
@@ -38,6 +39,7 @@ from goldener.utils import (
     split_sampling_among_chunks,
     get_sampling_count_from_ratios,
     get_ratios_for_counts,
+    force_non_zero_count,
 )
 
 logger = getLogger(__name__)
@@ -889,6 +891,10 @@ class GoldSelector:
         if select_count == 0 and isinstance(select_size, float):
             select_count = 1  # at least one sample
 
+        select_ratio = (
+            select_size if isinstance(select_size, float) else select_size / total_size
+        )
+
         selection_indices = self.get_selection_indices(
             selection_table, value, self.selection_key
         )
@@ -916,9 +922,21 @@ class GoldSelector:
                 f"which is more than the requested {select_count} samples."
             )
         elif self.distribute:
-            self._distributed_select(select_from, selection_table, select_count, value)
+            self._distributed_select(
+                select_from=select_from,
+                selection_table=selection_table,
+                select_count=select_count,
+                select_ratio=select_ratio,
+                value=value,
+            )
         else:
-            self._sequential_select(select_from, selection_table, select_count, value)
+            self._sequential_select(
+                select_from=select_from,
+                selection_table=selection_table,
+                select_count=select_count,
+                select_ratio=select_ratio,
+                value=value,
+            )
 
         logger.info(
             f"Selection table populated {
@@ -1341,6 +1359,7 @@ class GoldSelector:
         select_from: Table,
         selection_table: Table,
         select_count: int,
+        select_ratio: float,
         value: str | None,
     ) -> None:
         """Run sequential (single-process) selection process.
@@ -1353,6 +1372,7 @@ class GoldSelector:
             select_from: The source table with vectorized data.
             selection_table: The table to store selection results.
             select_count: Number of samples to select.
+            select_ratio: Ratio of samples to select (between 0 and 1).
             value: Value to assign to selected samples in the selection_key column.
 
         Raises:
@@ -1415,12 +1435,19 @@ class GoldSelector:
                     }
                 )
 
-                selection_label_counts = self._compute_label_counts_for_selection(
-                    selection_table=selection_table,
-                    labels=labels,
-                    select_count=loop_select_count,
-                    value=value,
-                    force_all_labels=force_all_labels,
+                selection_label_counts = (
+                    self._compute_label_counts_for_selection_from_selection_ratio(
+                        selection_table=selection_table,
+                        labels=labels,
+                        select_ratio=select_ratio,
+                        value=value,
+                    )
+                    if force_all_labels
+                    else self._compute_label_counts_from_not_selected_ratios(
+                        selection_table=selection_table,
+                        labels=labels,
+                        select_count=loop_select_count,
+                    )
                 )
                 # start with the labels with the lowest population in order to maximize the
                 # representativeness of the selection for all labels in multilabel tasks
@@ -1768,6 +1795,7 @@ class GoldSelector:
         select_from: Table,
         selection_table: Table,
         select_count: int,
+        select_ratio: float,
         value: str | None,
     ) -> None:
         """Run distributed selection process (not implemented).
@@ -1776,6 +1804,7 @@ class GoldSelector:
             select_from: The source table with vectorized data.
             selection_table: The table to store selection results.
             select_count: Number of samples to select.
+            select_ratio: Ratio of samples to select.
             value: Value to assign to selected samples in the selection_key column.
 
         Raises:
@@ -1806,18 +1835,16 @@ class GoldSelector:
 
         return set(indices[torch.tensor(selected_indices)].tolist())
 
-    def _compute_label_counts_for_selection(
+    def _compute_label_counts_from_not_selected_ratios(
         self,
         selection_table: Table,
         labels: list[str],
         select_count: int,
-        value: str | None = None,
-        force_all_labels: bool = True,
     ) -> dict[str, int]:
+        # when all the labels have already been selected from the selection ratio
+        # the missing samples are taken from remaining available ones
+        # based on the ratios of the populations favorizing the most represented labels
         assert self.label_key is not None
-        # When all labels are required, all the not selected samples and the selected samples for the current
-        # value are included in the count of the label.
-        # This allows to maximize the idempotence of the selection process
         label_counts = {}
         for label in labels:
             count = self.get_selection_count(
@@ -1827,27 +1854,9 @@ class GoldSelector:
                 label_key=self.label_key,
                 label_value=label,
             )
-            if force_all_labels:
-                count += self.get_selection_count(
-                    table=selection_table,
-                    value=value,
-                    selection_key=self.selection_key,
-                    label_key=self.label_key,
-                    label_value=label,
-                )
-
+            # only the remaining labels are kept
             if count > 0:
                 label_counts[label] = count
-            elif force_all_labels:
-                raise ValueError(
-                    f"Label '{label}' has no more selectable sample for value '{value}', but force_all_labels is True. "
-                    f"This might be due to an issue in the selection process or the data."
-                )
-            else:
-                logger.info(
-                    f"Label '{label}' has no more selectable sample for value '{value}'. "
-                    f"This label will not be selected in the current selection loop."
-                )
 
         label_ratios = {
             value: ratio
@@ -1858,5 +1867,43 @@ class GoldSelector:
         }
 
         return get_sampling_count_from_ratios(
-            label_ratios, select_count, force_non_zero=force_all_labels
+            label_ratios, select_count, force_non_zero=False
         )
+
+    def _compute_label_counts_for_selection_from_selection_ratio(
+        self,
+        selection_table: Table,
+        labels: list[str],
+        select_ratio: float,
+        value: str | None = None,
+    ) -> dict[str, int]:
+        # when selecting from the specified ratio, the label population include the available samples
+        # but as well the samples already sampled with the selection value
+        label_counts = {
+            label: self.get_selection_count(
+                table=selection_table,
+                value=value,
+                selection_key=self.selection_key,
+                label_key=self.label_key,
+                label_value=label,
+            )
+            + self.get_selection_count(
+                table=selection_table,
+                value=None,
+                selection_key=self.selection_key,
+                label_key=self.label_key,
+                label_value=label,
+            )
+            for label in labels
+        }
+
+        # The selection count for each label is first obtained from
+        # the flooring of the multiplication of the label count by the selection ratio
+        # then the label with 0 selected sampled are forced to be not 0
+        # by taking samples from the bigger labels
+        label_select_count = {
+            label: math.floor(count * select_ratio) if count > 0 else 0
+            for label, count in label_counts.items()
+        }
+
+        return force_non_zero_count(label_select_count)

--- a/goldener/select.py
+++ b/goldener/select.py
@@ -897,7 +897,7 @@ class GoldSelector:
         )
 
         select_ratio = (
-            select_size if isinstance(select_size, float) else select_size / total_size
+            select_size if isinstance(select_size, float) else select_count / total_size
         )
 
         selection_indices = self.get_selection_indices(
@@ -1862,6 +1862,11 @@ class GoldSelector:
             # only the remaining labels are kept
             if count > 0:
                 label_counts[label] = count
+
+        if not label_counts:
+            raise RuntimeError(
+                f"No more samples can be selected for any label. Cannot find {select_count} samples."
+            )
 
         label_ratios = {
             value: ratio

--- a/goldener/utils.py
+++ b/goldener/utils.py
@@ -574,7 +574,12 @@ def get_sampling_count_from_ratios(
         return dict(sorted(counts.items(), key=lambda x: x[1]))
 
     # If force_non_zero is activated, adjust counts to ensure no key has a count of zero
-    # first, the zero counts are identified and incremented by 1, while keeping track of how many were incremented
+    return force_non_zero_count(counts)
+
+
+def force_non_zero_count(counts: dict[T, int]) -> dict[T, int]:
+    # first, the zero counts are identified and incremented by 1,
+    # while keeping track of how many were incremented
     added = 0
     for key, count in counts.items():
         if count == 0:

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -614,7 +614,7 @@ class TestGoldSelector:
 
         # calling select_in_table when a table exists and allow_existing is False should raise
         with pytest.raises(
-            ValueError, match="Cannot select more unique data points than available"
+            ValueError, match="cannot be greater than the total number of samples"
         ):
             selector.select_in_table(dataset, select_size=21, value="train")
 


### PR DESCRIPTION
This pull request refactors and extends the label selection logic in `goldener/select.py` to improve how sample counts are computed and distributed, especially when enforcing label presence and handling selection ratios. The changes introduce clearer separation between selection strategies, add support for selection ratios, and improve code maintainability.

**Label selection logic improvements:**

* Refactored the computation of label counts into two distinct methods: `_compute_label_counts_for_selection_from_selection_ratio` (for ratio-based selection, ensuring all labels are represented according to the selection ratio) and `_compute_label_counts_from_not_selected_ratios` (for cases where missing samples are distributed based on remaining label populations). [[1]](diffhunk://#diff-bd9472afb5f4d1443584cbefe22523bc9c5581daa1ef19f08067fdcb0159e6e3L1418-R1450) [[2]](diffhunk://#diff-bd9472afb5f4d1443584cbefe22523bc9c5581daa1ef19f08067fdcb0159e6e3L1809-L1820) [[3]](diffhunk://#diff-bd9472afb5f4d1443584cbefe22523bc9c5581daa1ef19f08067fdcb0159e6e3L1861-R1909)
* Updated `_sequential_select` and `_distributed_select` to accept and use a new `select_ratio` parameter, allowing for ratio-based sample selection and more flexible selection strategies. [[1]](diffhunk://#diff-bd9472afb5f4d1443584cbefe22523bc9c5581daa1ef19f08067fdcb0159e6e3R1362) [[2]](diffhunk://#diff-bd9472afb5f4d1443584cbefe22523bc9c5581daa1ef19f08067fdcb0159e6e3R1375) [[3]](diffhunk://#diff-bd9472afb5f4d1443584cbefe22523bc9c5581daa1ef19f08067fdcb0159e6e3R1798) [[4]](diffhunk://#diff-bd9472afb5f4d1443584cbefe22523bc9c5581daa1ef19f08067fdcb0159e6e3R1807) [[5]](diffhunk://#diff-bd9472afb5f4d1443584cbefe22523bc9c5581daa1ef19f08067fdcb0159e6e3R894-R897) [[6]](diffhunk://#diff-bd9472afb5f4d1443584cbefe22523bc9c5581daa1ef19f08067fdcb0159e6e3L919-R939)

**Utility and code organization:**

* Added a new utility function `force_non_zero_count` to ensure that label counts never have a value of zero, and integrated it into the sample count calculation logic. [[1]](diffhunk://#diff-bd9472afb5f4d1443584cbefe22523bc9c5581daa1ef19f08067fdcb0159e6e3R42) [[2]](diffhunk://#diff-996a5e6a5c57e8a2806d8f5753ec8c8184cbf9766795fbafcc066c436f5af595L577-R582) [[3]](diffhunk://#diff-bd9472afb5f4d1443584cbefe22523bc9c5581daa1ef19f08067fdcb0159e6e3L1861-R1909)
* Cleaned up and clarified docstrings and comments to better explain the new logic and parameters. [[1]](diffhunk://#diff-bd9472afb5f4d1443584cbefe22523bc9c5581daa1ef19f08067fdcb0159e6e3R1375) [[2]](diffhunk://#diff-bd9472afb5f4d1443584cbefe22523bc9c5581daa1ef19f08067fdcb0159e6e3R1807) [[3]](diffhunk://#diff-bd9472afb5f4d1443584cbefe22523bc9c5581daa1ef19f08067fdcb0159e6e3L1809-L1820)

**Other improvements:**

* Added missing import for `math` used in new label count calculations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Start label selection by assigning samples to every label using the requested selection ratio, then fill remaining slots based on current label populations. Adds `select_ratio` support across sequential and distributed paths for predictable, balanced results.

- **New Features**
  - Ratio-based start ensures each label gets samples; no zero-count labels.
  - Compute and pass `select_ratio` for both int and float inputs to `_sequential_select` and `_distributed_select`.

- **Bug Fixes**
  - Compute `total_size` from `selection_table`; raise on empty table or when integer `select_size` exceeds available samples.
  - Use `math.ceil` for float `select_size` to guarantee at least one sample.
  - Raise a clear error when no labels have remaining selectable samples.

<sup>Written for commit f0aa497dc5012d7e779bf3ea3b1b3c4a5b050006. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

