### PR TITLE
Make the clustering in GoldSplitter really working

### DIFF
--- a/goldener/select.py
+++ b/goldener/select.py
@@ -886,7 +886,7 @@ class GoldSelector:
                 and `idx` (index of the sample) and `idx_vector` (index of the vector) columns as well.
 
         Raises:
-            ValueError: If select_size is a float not in the range (0.0, 1.0).
+            ValueError: If select_size is a float not in the range ]0.0, 1.0].
         """
         if isinstance(select_size, float):
             if not (0.0 < select_size <= 1.0):

--- a/goldener/select.py
+++ b/goldener/select.py
@@ -801,7 +801,12 @@ class GoldSelector:
         return selection_table
 
     def select_in_dataset(
-        self, select_from: Dataset | Table, select_count: int, value: str
+        self,
+        select_from: Dataset | Table,
+        select_size: int | float,
+        value: str,
+        restrict_to: set[int] | None = None,
+        restriction_idx_key: str = "idx_vector",
     ) -> GoldPxtTorchDataset:
         """Select a subset of samples using coresubset selection and return results as a GoldPxtTorchDataset.
 
@@ -820,15 +825,24 @@ class GoldSelector:
                 dictionary with at least the `vectorized_key` and `idx` keys after applying the collate_fn.
                 If the collate_fn is None, the dataset is expected to directly provide such batches.
                 If a Table is provided, it should contain at least the `vectorized_key`, `idx` and `idx_vector` columns.
-            select_count: Number of data points to select.
+            select_size: Number or ratio (between 0 and 1) of data points to select
             value: Value to set in the `selection_key` column for selected samples.
+            restrict_to: Optional set of indices to restrict the search to.
+                If provided, only the selected indices in `restriction_idx_key` will be used for the selection.
+            restriction_idx_key: Column name used to get sample indices for restriction.
 
         Returns:
             A GoldPxtTorchDataset containing at least the selection information in the `selection_key` key
                 and `idx` (index of the sample) and `idx_vector` (index of the vector) keys as well.
         """
 
-        selected_table = self.select_in_table(select_from, select_count, value)
+        selected_table = self.select_in_table(
+            select_from=select_from,
+            select_size=select_size,
+            value=value,
+            restrict_to=restrict_to,
+            restriction_idx_key=restriction_idx_key,
+        )
 
         selected_dataset = GoldPxtTorchDataset(selected_table, keep_cache=True)
 
@@ -838,7 +852,12 @@ class GoldSelector:
         return selected_dataset
 
     def select_in_table(
-        self, select_from: Dataset | Table, select_size: int | float, value: str | None
+        self,
+        select_from: Dataset | Table,
+        select_size: int | float,
+        value: str | None,
+        restrict_to: set[int] | None = None,
+        restriction_idx_key: str = "idx_vector",
     ) -> Table:
         """Select a subset of samples using coresubset selection and store results in a PixelTable table.
 
@@ -858,6 +877,9 @@ class GoldSelector:
                 If a Table is provided, it should contain at least the `vectorized_key`, `idx` and `idx_vector` columns.
             select_size: Number or ratio (between 0 and 1) of data points to select.
             value: Value to set in the `selection_key` column for selected samples.
+            restrict_to: Optional set of indices to restrict the search to.
+                If provided, only the selected indices in `restriction_idx_key` will be used for the selection.
+            restriction_idx_key: Column name used to get sample indices for restriction.
 
         Returns:
             A PixelTable Table containing at least the selection information in the `selection_key` column
@@ -867,9 +889,9 @@ class GoldSelector:
             ValueError: If select_size is a float not in the range (0.0, 1.0).
         """
         if isinstance(select_size, float):
-            if not (0.0 < select_size < 1.0):
+            if not (0.0 < select_size <= 1.0):
                 raise ValueError(
-                    "When select_size is a float, it must be in the range (0.0, 1.0)."
+                    "When select_size is a float, it must be in the range ]0.0, 1.0]."
                 )
         else:
             if select_size <= 0:
@@ -882,7 +904,16 @@ class GoldSelector:
         assert isinstance(select_from, Table)
 
         # define the number of element to sample
-        total_size = selection_table.select(selection_table.idx).distinct().count()
+        total_query = (
+            selection_table
+            if restrict_to is None
+            else selection_table.where(
+                get_expr_from_column_name(selection_table, restriction_idx_key).isin(
+                    restrict_to
+                )
+            )
+        )
+        total_size = total_query.select(selection_table.idx).distinct().count()
         if total_size == 0:
             raise ValueError("The selection table is empty.")
         if isinstance(select_size, int) and select_size > total_size:
@@ -901,7 +932,11 @@ class GoldSelector:
         )
 
         selection_indices = self.get_selection_indices(
-            selection_table, value, self.selection_key
+            selection_table,
+            value,
+            self.selection_key,
+            restrict_to=restrict_to,
+            restriction_idx_key=restriction_idx_key,
         )
         already_selected_count = len(selection_indices)
         if already_selected_count > 0:
@@ -933,6 +968,8 @@ class GoldSelector:
                 select_count=select_count,
                 select_ratio=select_ratio,
                 value=value,
+                restrict_to=restrict_to,
+                restriction_idx_key=restriction_idx_key,
             )
         else:
             self._sequential_select(
@@ -941,6 +978,8 @@ class GoldSelector:
                 select_count=select_count,
                 select_ratio=select_ratio,
                 value=value,
+                restrict_to=restrict_to,
+                restriction_idx_key=restriction_idx_key,
             )
 
         logger.info(
@@ -1258,6 +1297,8 @@ class GoldSelector:
         label_key: str | None = None,
         label_value: str | None = None,
         idx_key: str = "idx",
+        restrict_to: set[int] | None = None,
+        restriction_idx_key: str = "idx_vector",
     ) -> Query:
         """Get the Pixeltable query to access samples selected with a given value.
 
@@ -1268,11 +1309,13 @@ class GoldSelector:
             label_key: Optional column name used to filter samples by label.
             label_value: Optional label value to filter samples by label.
             idx_key: Column name used to get sample indices.
+            restrict_to: Optional set of indices to restrict the search to.
+                If provided, only the selected indices in `restriction_idx_key` will be used for the selection.
+            restriction_idx_key: Column name used to get sample indices for restriction.
 
         Returns:
             A PixelTable Query object that can be executed to access
                 the samples with the specified value (and label if specified).
-
 
         Raises:
             ValueError: If only one of `label_key` or `label_value` is provided (both must be set together).
@@ -1287,6 +1330,10 @@ class GoldSelector:
                 raise ValueError("label_key and label_value must be set together.")
             query = selection_col == value  # noqa: E712
 
+        if restrict_to is not None:
+            restrict_idx_col = get_expr_from_column_name(table, restriction_idx_key)
+            query = query & restrict_idx_col.isin(restrict_to)
+
         return table.where(query).select(idx_col).distinct()
 
     @staticmethod
@@ -1297,6 +1344,8 @@ class GoldSelector:
         label_key: str | None = None,
         label_value: str | None = None,
         idx_key: str = "idx",
+        restrict_to: set[int] | None = None,
+        restriction_idx_key: str = "idx_vector",
     ) -> set[int]:
         """Get the indices of samples selected with a given value.
 
@@ -1307,6 +1356,9 @@ class GoldSelector:
             label_key: Optional column name used to filter samples by label.
             label_value: Optional label value to filter samples by label.
             idx_key: Column name used to get sample indices.
+            restrict_to: Optional set of indices to restrict the search to.
+                If provided, only the selected indices in `restriction_idx_key` will be used for the selection.
+            restriction_idx_key: Column name used to get sample indices for restriction.
 
         Returns:
             A set of indices with the specified value (and label if specified).
@@ -1318,12 +1370,14 @@ class GoldSelector:
             [
                 row[idx_key]
                 for row in GoldSelector.get_selection_pxt_query(
-                    table,
-                    value,
-                    selection_key,
-                    label_key,
-                    label_value,
-                    idx_key,
+                    table=table,
+                    value=value,
+                    selection_key=selection_key,
+                    label_key=label_key,
+                    label_value=label_value,
+                    idx_key=idx_key,
+                    restrict_to=restrict_to,
+                    restriction_idx_key=restriction_idx_key,
                 ).collect()
             ]
         )
@@ -1336,6 +1390,8 @@ class GoldSelector:
         label_key: str | None = None,
         label_value: str | None = None,
         idx_key: str = "idx",
+        restrict_to: set[int] | None = None,
+        restriction_idx_key: str = "idx_vector",
     ) -> int:
         """Get the number of samples selected with a given value.
 
@@ -1346,17 +1402,22 @@ class GoldSelector:
             label_key: Optional column name used to filter samples by label.
             label_value: Optional label value to filter samples by label.
             idx_key: Column name used to get sample indices.
+            restrict_to: Optional set of indices to restrict the search to.
+                If provided, only the selected indices in `restriction_idx_key` will be used for the selection.
+            restriction_idx_key: Column name used to get sample indices for restriction.
 
         Returns:
             The number of samples with the specified value (and label if specified).
         """
         return GoldSelector.get_selection_pxt_query(
-            table,
-            value,
-            selection_key,
-            label_key,
-            label_value,
-            idx_key,
+            table=table,
+            value=value,
+            selection_key=selection_key,
+            label_key=label_key,
+            label_value=label_value,
+            idx_key=idx_key,
+            restrict_to=restrict_to,
+            restriction_idx_key=restriction_idx_key,
         ).count()
 
     def _sequential_select(
@@ -1366,6 +1427,8 @@ class GoldSelector:
         select_count: int,
         select_ratio: float,
         value: str | None,
+        restrict_to: set[int] | None = None,
+        restriction_idx_key: str = "idx_vector",
     ) -> None:
         """Run sequential (single-process) selection process.
 
@@ -1379,6 +1442,9 @@ class GoldSelector:
             select_count: Number of samples to select.
             select_ratio: Ratio of samples to select (between 0 and 1).
             value: Value to assign to selected samples in the selection_key column.
+            restrict_to: Optional set of indices to restrict the search to.
+                If provided, only the selected indices in `restriction_idx_key` will be used for the selection.
+            restriction_idx_key: Column name used to get sample indices for restriction.
 
         Raises:
             ValueError: If not enough samples are available for a label when `force_all_labels` is True.
@@ -1387,9 +1453,11 @@ class GoldSelector:
             label_col = get_expr_from_column_name(selection_table, self.label_key)
 
             already_selected_count = self.get_selection_count(
-                selection_table,
-                value,
-                self.selection_key,
+                table=selection_table,
+                value=value,
+                selection_key=self.selection_key,
+                restrict_to=restrict_to,
+                restriction_idx_key=restriction_idx_key,
             )
             logger.info(
                 f"The selection value '{value}' has already {already_selected_count} samples"
@@ -1435,6 +1503,8 @@ class GoldSelector:
                             self.selection_key,
                             self.label_key,
                             label,
+                            restrict_to=restrict_to,
+                            restriction_idx_key=restriction_idx_key,
                         )
                         for label in labels
                     }
@@ -1446,12 +1516,16 @@ class GoldSelector:
                         labels=labels,
                         select_ratio=select_ratio,
                         value=value,
+                        restrict_to=restrict_to,
+                        restriction_idx_key=restriction_idx_key,
                     )
                     if force_all_labels
                     else self._compute_label_counts_from_not_selected_ratios(
                         selection_table=selection_table,
                         labels=labels,
                         select_count=loop_select_count,
+                        restrict_to=restrict_to,
+                        restriction_idx_key=restriction_idx_key,
                     )
                 )
                 # start with the labels with the lowest population in order to maximize the
@@ -1472,11 +1546,13 @@ class GoldSelector:
                     # skip the label (over selection is not an issue)
                     label_count_status = (
                         self.get_selection_count(
-                            selection_table,
-                            value,
-                            self.selection_key,
-                            self.label_key,
-                            label_value,
+                            table=selection_table,
+                            value=value,
+                            selection_key=self.selection_key,
+                            label_key=self.label_key,
+                            label_value=label_value,
+                            restrict_to=restrict_to,
+                            restriction_idx_key=restriction_idx_key,
                         )
                         - label_counts_init[label_value]
                     )
@@ -1494,16 +1570,18 @@ class GoldSelector:
                         f"Selecting {label_count} samples for label '{label_value}' for value '{value}'"
                     )
                     self._select_label(
-                        select_from,
-                        selection_table,
-                        (
+                        select_from=select_from,
+                        selection_table=selection_table,
+                        select_count=(
                             label_count
                             if force_all_labels
                             else label_count - label_count_status
                         ),
-                        value,
+                        value=value,
                         label_value=label_value,
                         from_already=force_all_labels,
+                        restrict_to=restrict_to,
+                        restriction_idx_key=restriction_idx_key,
                     )
 
                 # after the first loop, labels with lower population might are allowed to be sampled again.
@@ -1515,10 +1593,12 @@ class GoldSelector:
         else:
             logger.info(f"Selecting {select_count} samples for value '{value}'")
             self._select_label(
-                select_from,
-                selection_table,
-                select_count,
-                value,
+                select_from=select_from,
+                selection_table=selection_table,
+                select_count=select_count,
+                value=value,
+                restrict_to=restrict_to,
+                restriction_idx_key=restriction_idx_key,
             )
 
     def _select_label(
@@ -1529,6 +1609,8 @@ class GoldSelector:
         value: str | None,
         label_value: str | None = None,
         from_already: bool = True,
+        restrict_to: set[int] | None = None,
+        restriction_idx_key: str = "idx_vector",
     ) -> None:
         """Perform coresubset selection for a specific label or all data.
 
@@ -1545,7 +1627,10 @@ class GoldSelector:
             from_already: Whether to restart selection from the already selected ones for the label.
                 If False, the selection is done to select the full select_count even if some samples have already
                 been selected for the label. If True, the selection is done to select only the remaining samples
-                 to reach select_count when counting the already selected ones for the label.
+                to reach select_count when counting the already selected ones for the label.
+            restrict_to: Optional set of indices to restrict the search to.
+                If provided, only the selected indices in `restriction_idx_key` will be used for the selection.
+            restriction_idx_key: Column name used to get sample indices for restriction.
 
         Raises:
             ValueError: If `select_count` exceeds the number of available unique data points in the dataset.
@@ -1564,6 +1649,8 @@ class GoldSelector:
             selection_key=self.selection_key,
             label_key=self.label_key,
             label_value=label_value,
+            restrict_to=restrict_to,
+            restriction_idx_key=restriction_idx_key,
         )
 
         # validate that there is still enough samples to select from
@@ -1574,6 +1661,8 @@ class GoldSelector:
             selection_key=self.selection_key,
             label_key=self.label_key,
             label_value=label_value,
+            restrict_to=restrict_to,
+            restriction_idx_key=restriction_idx_key,
         )
         if available_samples_for_selection_count < (
             select_count - current_selected_count
@@ -1586,12 +1675,17 @@ class GoldSelector:
         # (depending on data, a data point can have multiple vectors).
         # Then, the same data point can be selected multiple times if it has multiple vectors selected.
         # To achieve select_count of unique data points, we loop until we have enough unique data points selected.
+        available_query = selection_col == None  # noqa: E711
         if label_value is not None:
             assert self.label_key is not None
             label_col = get_expr_from_column_name(selection_table, self.label_key)
-            available_query = (selection_col == None) & (label_col == label_value)  # noqa: E712 E711
-        else:
-            available_query = selection_col == None  # noqa: E711
+            available_query = available_query & (label_col == label_value)  # noqa: E712 E711
+
+        if restrict_to is not None:
+            restricted_idx_col = get_expr_from_column_name(
+                selection_table, restriction_idx_key
+            )
+            available_query = available_query & restricted_idx_col.isin(restrict_to)
 
         while current_selected_count < select_count:
             logger.info(
@@ -1718,6 +1812,8 @@ class GoldSelector:
                         label_key=self.label_key,
                         label_value=label_value,
                         idx_key="idx_vector",
+                        restrict_to=restrict_to,
+                        restriction_idx_key=restriction_idx_key,
                     )
                     if already_selected_vector_indices:
                         anchors_list = [
@@ -1774,6 +1870,8 @@ class GoldSelector:
                     selection_key=self.selection_key,
                     label_key=self.label_key,
                     label_value=label_value,
+                    restrict_to=restrict_to,
+                    restriction_idx_key=restriction_idx_key,
                 )
 
                 if not from_already:
@@ -1802,6 +1900,8 @@ class GoldSelector:
         select_count: int,
         select_ratio: float,
         value: str | None,
+        restrict_to: set[int] | None = None,
+        restriction_idx_key: str = "idx_vector",
     ) -> None:
         """Run distributed selection process (not implemented).
 
@@ -1811,6 +1911,9 @@ class GoldSelector:
             select_count: Number of samples to select.
             select_ratio: Ratio of samples to select.
             value: Value to assign to selected samples in the selection_key column.
+            restrict_to: Optional set of indices to restrict the search to.
+                If provided, only the selected indices in `restriction_idx_key` will be used for the selection.
+            restriction_idx_key: Column name used to get sample indices for restriction.
 
         Raises:
             NotImplementedError: Always raised as distributed mode is not yet implemented.
@@ -1845,6 +1948,8 @@ class GoldSelector:
         selection_table: Table,
         labels: list[str],
         select_count: int,
+        restrict_to: set[int] | None = None,
+        restriction_idx_key: str = "idx_vector",
     ) -> dict[str, int]:
         # when all the labels have already been selected from the selection ratio
         # the missing samples are taken from remaining available ones
@@ -1858,6 +1963,8 @@ class GoldSelector:
                 selection_key=self.selection_key,
                 label_key=self.label_key,
                 label_value=label,
+                restrict_to=restrict_to,
+                restriction_idx_key=restriction_idx_key,
             )
             # only the remaining labels are kept
             if count > 0:
@@ -1886,6 +1993,8 @@ class GoldSelector:
         labels: list[str],
         select_ratio: float,
         value: str | None = None,
+        restrict_to: set[int] | None = None,
+        restriction_idx_key: str = "idx_vector",
     ) -> dict[str, int]:
         # when selecting from the specified ratio, the label population include the available samples
         # but as well the samples already sampled with the selection value
@@ -1896,6 +2005,8 @@ class GoldSelector:
                 selection_key=self.selection_key,
                 label_key=self.label_key,
                 label_value=label,
+                restrict_to=restrict_to,
+                restriction_idx_key=restriction_idx_key,
             )
             + self.get_selection_count(
                 table=selection_table,
@@ -1903,6 +2014,8 @@ class GoldSelector:
                 selection_key=self.selection_key,
                 label_key=self.label_key,
                 label_value=label,
+                restrict_to=restrict_to,
+                restriction_idx_key=restriction_idx_key,
             )
             for label in labels
         }

--- a/goldener/split.py
+++ b/goldener/split.py
@@ -97,6 +97,7 @@ class GoldSplitter:
 
     Attributes:
         sets: List of GoldSet configurations defining the splits.
+            They are required to split all the samples among them.
         selector: GoldSelector used to select samples for each set.
         descriptor: Optional GoldDescriptor used to describe the dataset.
         vectorizer: Optional GoldVectorizer used to vectorize the described dataset.
@@ -125,6 +126,7 @@ class GoldSplitter:
 
         Args:
             sets: List of GoldSet configurations defining the splits.
+                They are required to split all the samples among them.
             selector: GoldSelector used to select samples for each set.
             descriptor: Optional GoldDescriptor used to describe the dataset.
             vectorizer: Optional GoldVectorizer used to vectorize the described dataset.
@@ -266,6 +268,8 @@ class GoldSplitter:
                 f"All set sizes must be of the same type, got types {size_types}."
             )
 
+        # in case of integers, the max completion will be checked later
+        # based on the actual total number of samples in the dataset at query time
         check_sets_validity(
             sets, force_max=True if issubclass(size_types[0], float) else False
         )
@@ -420,13 +424,8 @@ class GoldSplitter:
             assert self.clusterizer is not None and self.n_clusters > 1
             clusterized = self.clusterizer.cluster_in_table(vectorized, self.n_clusters)
 
-        if isinstance(vectorized, Table):
-            sample_count = vectorized.select(vectorized.idx).distinct().count()
-        else:
-            selection_table = self.selector.setup_selection_table(vectorized)
-            sample_count = (
-                selection_table.select(selection_table.idx).distinct().count()
-            )
+        selection_table = self.selector.setup_selection_table(vectorized)
+        sample_count = selection_table.select(selection_table.idx).distinct().count()
 
         if sample_count is not None:
             check_sets_validity(self._sets, total=sample_count, force_max=True)
@@ -436,6 +435,20 @@ class GoldSplitter:
             set_count = get_sampling_count_from_size(
                 sampling_size=gold_set.size, total_size=sample_count
             )
+            already_selected_count = self.selector.get_selection_count(
+                selection_table,
+                selection_key=self.selector.selection_key,
+                value=gold_set.name,
+            )
+            if already_selected_count == set_count:
+                logger.info(f"{gold_set.name} has already been fully selected.")
+                continue
+
+            if already_selected_count > set_count:
+                raise ValueError(
+                    f"{gold_set.name} already contains selected samples and the size is above the specified size."
+                )
+
             logger.info(
                 f"Selecting samples for set '{gold_set.name}' with size {set_count} over {sample_count} samples."
             )
@@ -444,8 +457,10 @@ class GoldSplitter:
             # while the last one gathers all the remaining samples,
             # so we don't need to select it explicitly
             if idx_set < len(self._sets) - 1:
-                selected_table = (
-                    self._clusterized_selection(clusterized, set_count, gold_set)
+                selection_table = (
+                    self._clusterized_selection(
+                        clusterized, selection_table, set_count, gold_set
+                    )
                     if clusterized is not None
                     else self.selector.select_in_table(
                         vectorized, set_count, value=gold_set.name
@@ -457,17 +472,16 @@ class GoldSplitter:
                 )
                 # The last set is gathering all the remaining samples
                 selection_col = get_expr_from_column_name(
-                    selected_table, self.selector.selection_key
+                    selection_table, self.selector.selection_key
                 )
-                already_in_set_count = (
-                    selected_table.where(selection_col == gold_set.name)
-                    .select(selected_table.idx)
-                    .distinct()
-                    .count()
+                already_in_set_count = self.selector.get_selection_count(
+                    table=selection_table,
+                    selection_key=self.selector.selection_key,
+                    value=gold_set.name,
                 )
-                not_yet_selected = selected_table.where(selection_col == None)  # noqa: E711
+                not_yet_selected = selection_table.where(selection_col == None)  # noqa: E711
                 not_yet_selected_count = (
-                    not_yet_selected.select(selected_table.idx).distinct().count()
+                    not_yet_selected.select(selection_table.idx).distinct().count()
                 )
                 if not_yet_selected_count == 0 and already_in_set_count == 0:
                     raise ValueError(
@@ -478,7 +492,7 @@ class GoldSplitter:
                     logger.warning(
                         f"For the set '{gold_set.name}', the expected count was {set_count}, "
                         f"but got {already_in_set_count} already selected and {not_yet_selected_count} not yet selected samples. "
-                        f"This might be due to rounding issues."
+                        f"This might be due to rounding issues or the presence of already selected samples before splitting."
                     )
 
                 not_yet_selected.update(  # noqa: E711
@@ -487,7 +501,7 @@ class GoldSplitter:
 
         # Depending on the `in_described_table` flag, move the selection column to the described table
         # or keep it in the selected table.
-        split_table = selected_table
+        split_table = selection_table
         if self.in_described_table:
             logger.info(
                 "in_described_table is set to True, moving the selection column to the described table "
@@ -500,7 +514,7 @@ class GoldSplitter:
             for set_cfg in self._sets:
                 set_name = set_cfg.name
                 set_indices = self.selector.get_selection_indices(
-                    selected_table,
+                    selection_table,
                     selection_key=self.selector.selection_key,
                     value=set_name,
                 )
@@ -527,6 +541,7 @@ class GoldSplitter:
     def _clusterized_selection(
         self,
         clusterized: Table,
+        selection_table: Table,
         set_count: int,
         gold_set: GoldSet,
     ) -> Table:
@@ -543,7 +558,7 @@ class GoldSplitter:
         self.selector.collate_fn = pxt_torch_dataset_collate_fn
 
         try:
-            # define all the queries, select count and indices for each cluster
+            # validate the clustering has been run
             cluster_col = get_expr_from_column_name(
                 clusterized, self.clusterizer.cluster_key
             )
@@ -552,7 +567,7 @@ class GoldSplitter:
                     f"Clusterizer output column '{self.clusterizer.cluster_key}' contains null values."
                 )
 
-            # initial list of samples per cluster
+            # track the initial indices per cluster
             initial_clusters = [
                 self.clusterizer.get_cluster_indices(
                     table=clusterized,
@@ -567,84 +582,152 @@ class GoldSplitter:
             # so the selection might require multiple iterations to select the
             # expected number of samples for the set, cluster after cluster, based
             # on the number of available samples in each cluster at each iteration
-            already_selected: set[int] = set()
-            selected_table = None  # ensure it exists in the scope after the loop, even if no cluster is selected
-            selected_count = 0
+            already_selected: set[int] = self.selector.get_selection_indices(
+                selection_table,
+                selection_key=self.selector.selection_key,
+                value=gold_set.name,
+            )
+            selected_count = len(already_selected)
+            force_all_clusters = (
+                True  # the first loop is done like nothing is already selected
+            )
+            initial_cluster_selected_counts = {
+                cluster_idx: clusterized.where(
+                    (clusterized.idx.isin(already_selected))
+                    & (cluster_col == cluster_idx)
+                )
+                .select(clusterized.idx)
+                .distinct()
+                .count()
+                for cluster_idx in range(self.n_clusters)
+            }
             while selected_count < set_count:
                 loop_start = selected_count
 
-                # the new cluster sizes and associated selection count are computed
-                # from the samples not yet selected
-                cluster_sizes = [
-                    clusterized.where(
-                        (~clusterized.idx.isin(already_selected))
-                        & (cluster_col == cluster_idx)
-                    )
-                    .select(clusterized.idx)
-                    .distinct()
-                    .count()
-                    for cluster_idx in range(self.n_clusters)
-                ]
+                # the numbers of samples per cluster to select for the loop are computed
+                # from the samples not yet selected except for the first loop which take all the samples
+                # (make the process as much idempotent as possible )
                 cluster_select_counts = split_sampling_among_chunks(
-                    to_split=set_count - selected_count,
-                    chunk_sizes=cluster_sizes,
+                    to_split=(
+                        set_count if force_all_clusters else set_count - selected_count
+                    ),
+                    chunk_sizes=[
+                        clusterized.where(
+                            cluster_col == cluster_idx
+                            if force_all_clusters
+                            else (
+                                (clusterized.idx == cluster_idx)
+                                & (~clusterized.idx.isin(already_selected))
+                            )
+                        )
+                        .select(clusterized.idx)
+                        .distinct()
+                        .count()
+                        for cluster_idx in range(self.n_clusters)
+                    ],
                 )
+                # The monitoring of the selected count per cluster starts from the already selected
+                # count for the 1st loop (make the process as much idempotent as possible ).
+                # Then, it starts with a 0 value.
+                loop_cluster_selected_counts = (
+                    initial_cluster_selected_counts
+                    if force_all_clusters
+                    else {cluster_idx: 0 for cluster_idx in range(self.n_clusters)}
+                )
+
                 for cluster_idx, (
-                    cluster_size,
                     cluster_select_count,
                     initial_cluster,
                 ) in enumerate(
                     zip(
-                        cluster_sizes,
                         cluster_select_counts,
                         initial_clusters,
                         strict=True,
                     )
                 ):
+                    if loop_cluster_selected_counts[cluster_idx] > cluster_select_count:
+                        logger.info(
+                            f"Cluster {cluster_idx} has {loop_cluster_selected_counts[cluster_idx]} samples "
+                            f"which is equal or above the target for the current selection loop. Skipping this cluster."
+                        )
+
                     if selected_count >= set_count:
                         break
 
-                    # some samples from the cluster might have been already selected
-                    # in previous iterations or previous clusters ending up with nothing
-                    # to select in a given cluster
-                    available_in_cluster = initial_cluster - already_selected
-                    if len(available_in_cluster) == 0:
-                        logger.warning(
-                            f"Cluster {cluster_idx} has no available samples for selection. Skipping this cluster."
-                        )
-                        continue
-                    cluster_already_selected = cluster_size - len(available_in_cluster)
                     cluster_select_count = (
-                        cluster_select_count - cluster_already_selected
+                        cluster_select_count - loop_cluster_selected_counts[cluster_idx]
                     )
                     if cluster_select_count <= 0:
-                        logger.warning(
-                            f"Cluster {cluster_idx} has already enough selected samples. Skipping this cluster."
+                        logger.info(
+                            f"Cluster {cluster_idx} has no more samples to select. Skipping this cluster."
                         )
                         continue
+
+                    # some samples from the cluster might have been already selected
+                    # from previous clusters ending up with nothing to select in a given cluster
+                    available_in_cluster = initial_cluster - already_selected
+                    if len(available_in_cluster) == 0:
+                        logger.info(
+                            f"Cluster {cluster_idx} has no more available samples for selection. Skipping this cluster."
+                        )
+                        continue
+
+                    # when all samples can be selected, force the selector to take everything
+                    if cluster_select_count > len(available_in_cluster):
+                        logger.info(
+                            f"Cluster {cluster_idx} has only {len(available_in_cluster)} available samples, "
+                            f"but {cluster_select_count} samples are expected to be selected based on the clusterized sampling. "
+                            f"All the remaining samples in this cluster will be selected."
+                        )
+                        cluster_select_count = len(available_in_cluster)
 
                     logger.info(
                         f"Selecting {cluster_select_count} samples for set '{gold_set.name}' in "
                         f"cluster {cluster_idx} with {len(available_in_cluster)} available samples."
                     )
-                    selected_table = self.selector.select_in_table(
-                        GoldPxtTorchDataset(
-                            clusterized.where(
-                                (cluster_col == cluster_idx)
-                                & (clusterized.idx.isin(available_in_cluster))
-                            )
-                        ),
-                        len(already_selected) + cluster_select_count,
+                    cluster_pool = clusterized.where(
+                        (cluster_col == cluster_idx)
+                        & (clusterized.idx.isin(available_in_cluster))
+                    )
+                    remaining_vectors = set(
+                        [
+                            row["idx_vector"]
+                            for row in cluster_pool.select(
+                                clusterized.idx_vector
+                            ).collect()
+                        ]
+                    )
+
+                    selection_table = self.selector.select_in_table(
+                        select_from=GoldPxtTorchDataset(cluster_pool),
+                        select_size=cluster_select_count,
                         value=gold_set.name,
+                        restrict_to=remaining_vectors,
+                        restriction_idx_key="idx_vector",
                     )
 
                     # update the elements allowing to compute the selection specs for the next clusters
                     already_selected = self.selector.get_selection_indices(
-                        selected_table,
+                        selection_table,
                         selection_key=self.selector.selection_key,
                         value=gold_set.name,
                     )
                     selected_count = len(already_selected)
+                    loop_cluster_selected_counts = {
+                        cluster_idx: loop_cluster_selected_counts[cluster_idx]
+                        + clusterized.where(
+                            (clusterized.idx == cluster_idx)
+                            & (clusterized.idx.isin(already_selected))
+                            & (clusterized.idx_vector.isin(remaining_vectors))
+                        )
+                        .select(clusterized.idx)
+                        .distinct()
+                        .count()
+                        for cluster_idx in range(self.n_clusters)
+                    }
+                    force_all_clusters = (
+                        False  # only the first loop ignore the already selected samples
+                    )
 
                 if selected_count == loop_start:
                     # if after going through all the clusters, no new sample has been selected, it means that there is not enough data to select from
@@ -657,12 +740,7 @@ class GoldSplitter:
             # restore the original collate_fn of the selector after cluster-wise selection is done
             self.selector.collate_fn = selection_collate_fn
 
-        if selected_table is None:
-            raise RuntimeError(
-                f"no selection table was created during clusterized selection for set '{gold_set.name}'."
-            )
-
-        return selected_table
+        return selection_table
 
     def _drop_tables(self, drop_all: bool = True) -> None:
         """Drop all intermediate tables created during the splitting process.

--- a/goldener/split.py
+++ b/goldener/split.py
@@ -616,7 +616,7 @@ class GoldSplitter:
                             cluster_col == cluster_idx
                             if force_all_clusters
                             else (
-                                (clusterized.idx == cluster_idx)
+                                (cluster_col == cluster_idx)
                                 & (~clusterized.idx.isin(already_selected))
                             )
                         )
@@ -716,7 +716,7 @@ class GoldSplitter:
                     loop_cluster_selected_counts = {
                         cluster_idx: loop_cluster_selected_counts[cluster_idx]
                         + clusterized.where(
-                            (clusterized.idx == cluster_idx)
+                            (cluster_col == cluster_idx)
                             & (clusterized.idx.isin(already_selected))
                             & (clusterized.idx_vector.isin(remaining_vectors))
                         )

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -252,7 +252,7 @@ class TestGoldSelector:
         with pytest.raises(
             ValueError, match="When select_size is a float, it must be in the range"
         ):
-            selector.select_in_table(dataset, select_size=1.0, value="train")
+            selector.select_in_table(dataset, select_size=1.1, value="train")
 
         with pytest.raises(ValueError, match="select_size must be a positive integer"):
             selector.select_in_table(dataset, select_size=0, value="train")
@@ -723,7 +723,7 @@ class TestGoldSelector:
             table_path=table_path, allow_existing=False, batch_size=10, max_batches=2
         )
 
-        dataset = selector.select_in_dataset(dataset, select_count=3, value="train")
+        dataset = selector.select_in_dataset(dataset, select_size=3, value="train")
 
         assert isinstance(dataset, GoldPxtTorchDataset)
 
@@ -788,7 +788,7 @@ class TestGoldSelector:
             drop_table=True,
         )
 
-        dataset = selector.select_in_dataset(dataset, select_count=3, value="train")
+        dataset = selector.select_in_dataset(dataset, select_size=3, value="train")
 
         sleep(1)
         with pytest.raises(

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -576,6 +576,9 @@ class TestGoldSplitter:
         basic_splitter.split_in_table(to_split=dataset)
 
         basic_splitter.max_batches = None
+        _ = basic_splitter.split_in_table(
+            to_split=dataset
+        )  # do a 1st split to simulate when the split is totally done as well
         split_table = basic_splitter.split_in_table(to_split=dataset)
         splitted = basic_splitter.get_split_indices(
             split_table,
@@ -866,7 +869,7 @@ class TestGoldSplitter:
             table_path="unit_test.clusterizer_split",
             clustering_tool=GoldRandomClusteringTool(random_state=0),
             label_key="label",
-            allow_existing=False,
+            allow_existing=True,
         )
 
         splitter = GoldSplitter(
@@ -876,23 +879,26 @@ class TestGoldSplitter:
             vectorizer=None,
             clusterizer=clusterizer,
             n_clusters=2,
+            allow_existing=True,
         )
 
-        split_table = splitter.split_in_table(
-            to_split=DummyDataset(
-                [
-                    {
-                        "vectorized": torch.rand(
-                            3,
-                        ),
-                        "idx": idx_vector // 4,
-                        "label": "dummy",
-                        "idx_vector": idx_vector,
-                    }
-                    for idx_vector in range(120)
-                ]
-            )
+        dataset = DummyDataset(
+            [
+                {
+                    "vectorized": torch.rand(
+                        3,
+                    ),
+                    "idx": idx_vector // 4,
+                    "label": "dummy",
+                    "idx_vector": idx_vector,
+                }
+                for idx_vector in range(120)
+            ]
         )
+
+        # validate using clustering and then restart while alreayd done
+        splitter.split_in_table(to_split=dataset)
+        split_table = splitter.split_in_table(to_split=dataset)
 
         splitted = splitter.get_split_indices(
             split_table,

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -896,7 +896,7 @@ class TestGoldSplitter:
             ]
         )
 
-        # validate using clustering and then restart while alreayd done
+        # validate using clustering and then restart while already done
         splitter.split_in_table(to_split=dataset)
         split_table = splitter.split_in_table(to_split=dataset)
 


### PR DESCRIPTION
## Pull request overview

This PR improves GoldSplitter’s clusterized splitting/idempotency behavior and extends GoldSelector’s selection APIs to support restricting selection operations to a specified subset of indices (via `restrict_to` + `restriction_idx_key`), including updated ratio handling semantics.

**Changes:**
- Add `restrict_to` / `restriction_idx_key` plumbing across selection entry points and internal selection helpers to constrain queries/counts/selection to a subset.
- Adjust float `select_size` validation to allow `1.0` (ratio range becomes `(0.0, 1.0]`) and propagate the new semantics through the selection flow.
- Update splitting + tests to exercise “restart when already done” behavior, including for clusterized splits.

### Reviewed changes

Copilot reviewed 3 out of 3 changed files in this pull request and generated 5 comments.

| File | Description |
| ---- | ----------- |
| `goldener/select.py` | Adds subset-restricted selection support across query/count/index retrieval and selection routines; updates float ratio validation. |
| `goldener/split.py` | Reworks clusterized selection to better support idempotent restarts and integrates restricted selection during cluster-wise selection. |
| `tests/test_split.py` | Updates/extends restart and clusterizer split tests to validate idempotent behavior with existing tables. |


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make cluster-based splitting reliable and restartable. `GoldSelector` adds subset-restricted selection and accepts ratio-based sizes up to 1.0; `GoldSplitter` always uses a selection table and handles restarts safely.

- **New Features**
  - Add `restrict_to` and `restriction_idx_key` across selection APIs/helpers to limit selection/counting to a subset (e.g., by `idx_vector`).
  - Accept float `select_size` in ]0.0, 1.0]; propagate the semantics and rename `select_in_dataset` param from `select_count` to `select_size`.

- **Bug Fixes**
  - Rework clusterized selection in `GoldSplitter`: validate cluster assignments, compute first-pass per-cluster targets from full data, track per-cluster selected counts, respect already-selected samples across restarts, restrict selection to each cluster via `idx_vector`, and take all remaining when a cluster is smaller than its target.
  - Make splits idempotent: always build/use a selection table for counts/updates, skip fully selected sets, error on over-selection, and let the last set gather leftovers with clear warnings; update tests for restarts, clustered splits, and the new ratio validation.

<sup>Written for commit 551c83c3cf226810ef0ca5cdc36b0399de8fe9e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

