### PR TITLE
replace embedder by descriptor in GOLD_SPLIT.md

### DIFF
--- a/docs/posts/GOLD_SPLIT.md
+++ b/docs/posts/GOLD_SPLIT.md
@@ -12,7 +12,7 @@
 In [Goldener](https://github.com/goldener-data/goldener), pretrained models and coreset selection algorithms can be leveraged to make smart splits (as opposed to the usual random split).
 
 ```python
-# Create an embedder to access the semantic representation
+# Create a descriptor to access the semantic representation
 embedder_config = GoldTorchEmbeddingToolConfig(
     model=my_model,
     layers=my_layers,


### PR DESCRIPTION
This pull request updates the documentation in `docs/posts/GOLD_SPLIT.md` to use more accurate terminology. Specifically, the term "embedder" has been replaced with "descriptor" to better reflect the functionality being described.

- Documentation terminology update:
  * Changed the comment in the code example from "Create an embedder" to "Create a descriptor" for clarity and accuracy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced "embedder" with "descriptor" in `docs/posts/GOLD_SPLIT.md` to match current terminology and better reflect the tool’s role in providing semantic descriptors. This clarifies the code example and avoids confusion for readers.

<sup>Written for commit c75cb12556ccd83230365a6f6917642d270b0f80. Summary will update on new commits. <a href="https://cubic.dev/pr/goldener-data/goldener/pull/217?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

