### PR TITLE
release-v6.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "goldener"
-version = "6.5.0"
+version = "6.6.0"
 description = "Goldener - Make your data even more valuable"
 readme = "README.md"
 license-files= ["LICENSE"]

--- a/uv.lock
+++ b/uv.lock
@@ -853,7 +853,7 @@ wheels = [
 
 [[package]]
 name = "goldener"
-version = "6.5.0"
+version = "6.6.0"
 source = { virtual = "." }
 dependencies = [
     { name = "coreax" },


### PR DESCRIPTION
This pull request updates the project version in the `pyproject.toml` file from 6.5.0 to 6.6.0.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `goldener` from 6.5.0 to 6.6.0 for the v6.6.0 release. Updates `pyproject.toml` and syncs `uv.lock`; no code changes.

<sup>Written for commit 601f48079c43b3ea0518b0ee6cff1e9229dcb1b3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

