### PR TITLE
docs: fix incorrect GoldSKLearnClusteringTool docstring

### DIFF
--- a/goldener/clusterize.py
+++ b/goldener/clusterize.py
@@ -165,7 +165,7 @@ def get_random_chunk_assignment(
 
 
 class GoldSKLearnClusteringTool(GoldClusteringTool):
-    """Chunk data randomly into clusters of almost equal size."""
+    """Cluster data using a wrapped scikit-learn clustering estimator."""
 
     def __init__(self, tool: ClusterMixin) -> None:
         if not hasattr(tool, "predict"):


### PR DESCRIPTION
Fixes #233. GoldSKLearnClusteringTool's docstring was copy-pasted from
GoldRandomClusteringTool ("Chunk data randomly into clusters of almost
equal size") but the class actually wraps a real scikit-learn clustering
estimator (self.tool.fit(...).labels_) — genuine data-driven clustering,
not random assignment.

Verified: fit a wrapped KMeans on two well-separated synthetic clusters;
confirmed same-cluster points get the same label and different clusters
get different labels.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected the GoldSKLearnClusteringTool docstring to state it clusters data using a wrapped `scikit-learn` estimator, not random chunking. This clarifies behavior and avoids confusion with GoldRandomClusteringTool.

<sup>Written for commit 21edfdbaac4f1dd7a6eea445d1089fe9ce46163d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/goldener-data/goldener/pull/237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

