### PR TITLE
docs: add runnable examples for reduce.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,19 +161,18 @@ for cluster_id in range(10):
 
 ## Reducing dimensionality
 
-Before clustering or visualizing embeddings, it's often useful to reduce their dimensionality.
-Goldener wraps common reducers like PCA, UMAP, and TSNE (or any fitted `torch.nn.Module`) behind
-the same simple interface.
+Depending on the dataset (size, data type, task), the computation tackled by Goldener can be quite resource intensive and time consuming. The dimensionality reduction aims to reduce the memory footprint and increase the speed for the downstream task. It can be quite useful to adapt the computation to the hardware constraints or access results in time constrained situation.
 
 ```python
 import torch
 from sklearn.decomposition import PCA
 from goldener import GoldSKLearnReductionTool
 
-embeddings = torch.randn(50, 16)  # 50 embeddings of dimension 16
+# 50 embeddings of dimension 16
+x = torch.randn(50, 16)
 
 reducer = GoldSKLearnReductionTool(PCA(n_components=2))
-reduced = reducer.fit_transform(embeddings)
+x_reduced = reducer.fit_transform(x)  # shape: (50, 2)
 ```
 
 # Installation

--- a/README.md
+++ b/README.md
@@ -159,6 +159,48 @@ for cluster_id in range(10):
 
 ```
 
+## Reducing dimensionality
+
+Before clustering or visualizing embeddings, it's often useful to reduce their dimensionality.
+Goldener wraps both scikit-learn-style reducers (PCA, UMAP, TSNE, GaussianRandomProjection) and
+any fitted `torch.nn.Module`, so either kind of reducer works with the same interface.
+
+```python
+import torch
+from sklearn.decomposition import PCA
+from goldener import GoldSKLearnReductionTool
+
+# 50 embeddings of dimension 16
+x = torch.randn(50, 16)
+
+reducer = GoldSKLearnReductionTool(PCA(n_components=2))
+x_reduced = reducer.fit_transform(x)
+
+print(x_reduced.shape)  # torch.Size([50, 2])
+```
+
+`fit()` and `transform()` are also available separately, so you can fit once and reuse the reducer
+on new data:
+
+```python
+reducer = GoldSKLearnReductionTool(PCA(n_components=2))
+reducer.fit(x)
+x_transformed = reducer.transform(x)
+```
+
+To reduce with a torch model instead (e.g. a learned projection head), wrap it with
+`GoldTorchModuleReductionTool`:
+
+```python
+from goldener import GoldTorchModuleReductionTool
+
+linear_reducer = torch.nn.Linear(16, 3)
+tool = GoldTorchModuleReductionTool(reducer=linear_reducer)
+x_out = tool.transform(x)
+
+print(x_out.shape)  # torch.Size([50, 3])
+```
+
 # Installation
 
 Installing Goldener is as simple as running the following command:

--- a/README.md
+++ b/README.md
@@ -162,43 +162,18 @@ for cluster_id in range(10):
 ## Reducing dimensionality
 
 Before clustering or visualizing embeddings, it's often useful to reduce their dimensionality.
-Goldener wraps both scikit-learn-style reducers (PCA, UMAP, TSNE, GaussianRandomProjection) and
-any fitted `torch.nn.Module`, so either kind of reducer works with the same interface.
+Goldener wraps common reducers like PCA, UMAP, and TSNE (or any fitted `torch.nn.Module`) behind
+the same simple interface.
 
 ```python
 import torch
 from sklearn.decomposition import PCA
 from goldener import GoldSKLearnReductionTool
 
-# 50 embeddings of dimension 16
-x = torch.randn(50, 16)
+embeddings = torch.randn(50, 16)  # 50 embeddings of dimension 16
 
 reducer = GoldSKLearnReductionTool(PCA(n_components=2))
-x_reduced = reducer.fit_transform(x)
-
-print(x_reduced.shape)  # torch.Size([50, 2])
-```
-
-`fit()` and `transform()` are also available separately, so you can fit once and reuse the reducer
-on new data:
-
-```python
-reducer = GoldSKLearnReductionTool(PCA(n_components=2))
-reducer.fit(x)
-x_transformed = reducer.transform(x)
-```
-
-To reduce with a torch model instead (e.g. a learned projection head), wrap it with
-`GoldTorchModuleReductionTool`:
-
-```python
-from goldener import GoldTorchModuleReductionTool
-
-linear_reducer = torch.nn.Linear(16, 3)
-tool = GoldTorchModuleReductionTool(reducer=linear_reducer)
-x_out = tool.transform(x)
-
-print(x_out.shape)  # torch.Size([50, 3])
+reduced = reducer.fit_transform(embeddings)
 ```
 
 # Installation


### PR DESCRIPTION
reduce.py has two real classes (GoldSKLearnReductionTool,
GoldTorchModuleReductionTool) with zero usage examples anywhere, unlike
select/split/clustering which each get one in the README.

Added a "Reducing dimensionality" section with fully runnable examples
(concrete synthetic data, no placeholders) covering fit_transform, the
separate fit()/transform() path, and wrapping a torch.nn.Module.

Verified by actually running each example against the current code —
confirmed output shapes match exactly what's documented.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a "Reducing dimensionality" section to the README with a runnable `GoldSKLearnReductionTool` (PCA) `fit_transform` example, using the reviewer-suggested wording and an inline shape comment. Drops the separate `fit()`/`transform()` example to avoid TSNE confusion.

<sup>Written for commit c299c7cf2c4f351eb57d92ef4f1c81ec4b495ad8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/goldener-data/goldener/pull/238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

