### PR TITLE
test: add edge-case coverage for get_random_chunk_assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,48 @@ for cluster_id in range(10):
 
 ```
 
+## Reducing dimensionality
+
+Before clustering or visualizing embeddings, it's often useful to reduce their dimensionality.
+Goldener wraps both scikit-learn-style reducers (PCA, UMAP, TSNE, GaussianRandomProjection) and
+any fitted `torch.nn.Module`, so either kind of reducer works with the same interface.
+
+```python
+import torch
+from sklearn.decomposition import PCA
+from goldener import GoldSKLearnReductionTool
+
+# 50 embeddings of dimension 16
+x = torch.randn(50, 16)
+
+reducer = GoldSKLearnReductionTool(PCA(n_components=2))
+x_reduced = reducer.fit_transform(x)
+
+print(x_reduced.shape)  # torch.Size([50, 2])
+```
+
+`fit()` and `transform()` are also available separately, so you can fit once and reuse the reducer
+on new data:
+
+```python
+reducer = GoldSKLearnReductionTool(PCA(n_components=2))
+reducer.fit(x)
+x_transformed = reducer.transform(x)
+```
+
+To reduce with a torch model instead (e.g. a learned projection head), wrap it with
+`GoldTorchModuleReductionTool`:
+
+```python
+from goldener import GoldTorchModuleReductionTool
+
+linear_reducer = torch.nn.Linear(16, 3)
+tool = GoldTorchModuleReductionTool(reducer=linear_reducer)
+x_out = tool.transform(x)
+
+print(x_out.shape)  # torch.Size([50, 3])
+```
+
 # Installation
 
 Installing Goldener is as simple as running the following command:

--- a/tests/test_clusterize.py
+++ b/tests/test_clusterize.py
@@ -138,6 +138,36 @@ class TestGetRandomChunkAssignment:
         ):
             get_random_chunk_assignment([], max_chunk_size=10, random_state=0)
 
+    def test_with_negative_max_chunk_size(self):
+        with pytest.raises(
+            ValueError, match="max_chunk_size must be a positive integer"
+        ):
+            get_random_chunk_assignment(
+                list(range(15)), max_chunk_size=-3, random_state=0
+            )
+
+    def test_exact_division_produces_no_spurious_extra_chunk(self):
+        # 12 / 4 divides evenly -- math.ceil should not create a 4th, tiny chunk.
+        to_chunk = list(range(12))
+        max_chunk_size = 4
+
+        chunks = get_random_chunk_assignment(
+            to_chunk, max_chunk_size=max_chunk_size, random_state=0
+        )
+
+        assert len(chunks) == 3
+        assert all(len(ch) == max_chunk_size for ch in chunks)
+
+    def test_max_chunk_size_of_1_splits_every_index_into_its_own_chunk(self):
+        to_chunk = list(range(5))
+
+        chunks = get_random_chunk_assignment(to_chunk, max_chunk_size=1, random_state=0)
+
+        assert len(chunks) == len(to_chunk)
+        assert all(len(ch) == 1 for ch in chunks)
+        flattened = [idx for ch in chunks for idx in ch]
+        assert sorted(flattened) == sorted(to_chunk)
+
 
 class TestGoldSKLearnClusteringTool:
     def test_init_raises_when_tool_has_no_predict(self):


### PR DESCRIPTION
get_random_chunk_assignment() combines ceiling-division math with random
assignment, but existing tests never covered: negative max_chunk_size
(only ==0 was tested), exact-division chunk counts (does math.ceil avoid
a spurious extra tiny chunk?), and max_chunk_size=1 (the most extreme
split).

Probed all three manually against current behavior before writing
anything — no bug found, all three are correct. Added as regression
tests. Full test file still green (38 passed).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add edge-case tests for get_random_chunk_assignment (negative max size, exact division, and max size = 1) to prevent regressions. Add runnable README examples for `GoldSKLearnReductionTool` and `GoldTorchModuleReductionTool` showing fit_transform and separate fit/transform.

<sup>Written for commit a8aa0cfc6a285fcd4f92b91843e799ee49d0bd9e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/goldener-data/goldener/pull/239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

