### PR TITLE
fix: default collate_fn to pxt_torch_dataset_collate_fn in all GoldDoer classes

### DIFF
--- a/goldener/clusterize.py
+++ b/goldener/clusterize.py
@@ -21,6 +21,7 @@ from goldener.pxt_utils import (
     make_batch_ready_for_table,
     check_pxt_table_has_primary_key,
     get_sample_row_from_idx,
+    pxt_torch_dataset_collate_fn,
 )
 from goldener.reduce import GoldReductionTool, GoldReductionToolWithFit
 from goldener.torch_utils import get_dataset_sample_dict
@@ -234,7 +235,8 @@ class GoldClusterizer:
         chunk: Optional chunk size for processing data in chunks to reduce memory consumption.
         collate_fn: Optional function to collate dataset samples into batches composed of
             dictionaries with at least the key specified by `vectorized_key` returning a PyTorch Tensor.
-            If None, the dataset is expected to directly provide such batches.
+            If None, `pxt_torch_dataset_collate_fn` is used, which preserves list-valued
+            fields as one list per sample.
         vectorized_key: Key in the batch dictionary that contains the vectorized data for the clustering. Default is "vectorized".
         include_vectorized_in_table: Whether to keep the vectorized data in the cluster table.
             It is only applied if the cluster table is created from a Table (it is forced anyway for Dataset). Default is False.
@@ -288,7 +290,8 @@ class GoldClusterizer:
             chunk: Optional chunk size for processing data in chunks to reduce memory consumption.
             collate_fn: Optional function to collate dataset samples into batches composed of
                 dictionaries with at least the key specified by `vectorized_key` returning a PyTorch Tensor.
-                If None, the dataset is expected to directly provide such batches.
+                If None, `pxt_torch_dataset_collate_fn` is used, which preserves list-valued
+                fields as one list per sample.
             vectorized_key: Key in the batch dictionary that contains the vectorized data for the clustering. Default is "vectorized".
             include_vectorized_in_table: Whether to keep the vectorized data in the cluster table. Defaults to False.
                     It is only applied if the cluster table is created from a Table (it is forced anyway for Dataset).
@@ -315,7 +318,9 @@ class GoldClusterizer:
         if chunk is not None and chunk <= 0:
             raise ValueError("chunk must be a positive integer or None.")
         self.chunk = chunk
-        self.collate_fn = collate_fn
+        self.collate_fn = (
+            collate_fn if collate_fn is not None else pxt_torch_dataset_collate_fn
+        )
         self.vectorized_key = vectorized_key
         self.include_vectorized_in_table = include_vectorized_in_table
         self.cluster_key = cluster_key
@@ -348,7 +353,6 @@ class GoldClusterizer:
         Args:
             cluster_from: Dataset or Table to cluster. If a Dataset is provided, each item should be a
                 dictionary with at least the `vectorized_key`, `idx_vector` and `idx` keys after applying the collate_fn.
-                If the collate_fn is None, the dataset is expected to directly provide such batches.
                 If a Table is provided, it should contain at least the `vectorized_key` and `idx` columns.
             n_clusters: Number of clusters to create.
         Returns:
@@ -380,7 +384,6 @@ class GoldClusterizer:
         Args:
             cluster_from: Dataset or Table to select from. If a Dataset is provided, each item should be a
                 dictionary with at least the `vectorized_key` and `idx` keys after applying the collate_fn.
-                If the collate_fn is None, the dataset is expected to directly provide such batches.
                 If a Table is provided, it should contain at least the `vectorized_key`, `idx` and `idx_vector` columns.
             n_clusters: Number of clusters to create.
 
@@ -509,7 +512,7 @@ class GoldClusterizer:
                 expected_keys=[self.vectorized_key],
             )
 
-            vectorized_value = sample[self.vectorized_key]
+            vectorized_value = sample[self.vectorized_key].squeeze(0)
             cluster_table.add_column(
                 **{
                     self.vectorized_key: pxt.Array[  # type: ignore[misc]
@@ -605,7 +608,9 @@ class GoldClusterizer:
                 expected=[self.vectorized_key],
             )
 
-            vectorized_value = sample[self.vectorized_key].detach().cpu().numpy()
+            vectorized_value = (
+                sample[self.vectorized_key].squeeze(0).detach().cpu().numpy()
+            )
             cluster_table.add_column(
                 **{
                     self.vectorized_key: pxt.Array[  # type: ignore[misc]

--- a/goldener/describe.py
+++ b/goldener/describe.py
@@ -490,7 +490,7 @@ class GoldDescriptor:
             to_describe_dataset,
             batch_size=self.batch_size,
             num_workers=self.num_workers,
-            collate_fn=self.collate_fn,
+            collate_fn=self.collate_fn or pxt_torch_dataset_collate_fn,
         )
 
         ready_to_insert: list[dict[str, Any]] = []

--- a/goldener/describe.py
+++ b/goldener/describe.py
@@ -53,7 +53,8 @@ class GoldDescriptor:
             applied by the `collate_fn`.
         collate_fn: Optional function to collate dataset samples into batches composed of
             dictionaries with at least the key specified by `data_key` returning a PyTorch Tensor.
-            If None, the dataset is expected to directly provide such batches. It should format
+            If None, `pxt_torch_dataset_collate_fn` is used, which preserves list-valued
+            fields as one list per sample. It should format
             the value at `data_key` in the format expected by the embedder.
         data_key: Key in the batch dictionary that contains the data to compute embeddings from. Default is "data".
         target_key: Key in the batch dictionary that contains the target/label information. Default is "target".
@@ -118,6 +119,7 @@ class GoldDescriptor:
             vectorizer: Optional TensorVectorizer to further vectorize the computed embeddings.
             transform: Optional transformation to apply before embedding computation.
             collate_fn: Optional function to collate dataset samples into batches.
+                If None, `pxt_torch_dataset_collate_fn` is used.
             data_key: Key in the batch dictionary containing the data. Defaults to "data".
             target_key: Key in the batch dictionary containing the target/label. Defaults to "target".
             label_key: Optional key for labels in the batch dictionary. Default is None.
@@ -143,7 +145,9 @@ class GoldDescriptor:
         self.embedder = embedder
         self.vectorizer = vectorizer
         self.transform = transform
-        self.collate_fn = collate_fn
+        self.collate_fn = (
+            collate_fn if collate_fn is not None else pxt_torch_dataset_collate_fn
+        )
         self.data_key = data_key
         self.target_key = target_key
         self.label_key = label_key
@@ -184,7 +188,7 @@ class GoldDescriptor:
         Args:
             to_describe: Dataset or Table to be described. If a Dataset is provided, each item should be a
                 dictionary with at least the key specified by `data_key` after applying the collate_fn.
-                If the collate_fn is None, the dataset is expected to directly provide such batches. If a Table is provided,
+                If a Table is provided,
                 it should contain both 'idx' and `data_key` columns.
 
         Returns:
@@ -218,7 +222,7 @@ class GoldDescriptor:
         Args:
             to_describe: Dataset or Table to be described. If a Dataset is provided, each item should be a
                 dictionary with at least the key specified by `data_key` after applying the collate_fn.
-                If the collate_fn is None, the dataset is expected to directly provide such batches. If a Table is provided,
+                If a Table is provided,
                 it should contain both 'idx' and `data_key` columns.
 
         Returns:
@@ -490,7 +494,7 @@ class GoldDescriptor:
             to_describe_dataset,
             batch_size=self.batch_size,
             num_workers=self.num_workers,
-            collate_fn=self.collate_fn or pxt_torch_dataset_collate_fn,
+            collate_fn=self.collate_fn,
         )
 
         ready_to_insert: list[dict[str, Any]] = []

--- a/goldener/pxt_utils.py
+++ b/goldener/pxt_utils.py
@@ -129,11 +129,12 @@ def pxt_torch_dataset_collate_fn(batch: list[dict[str, Any]]) -> dict[str, Any]:
         batch: A list of samples, where each sample is a dictionary.
 
     Returns:
-        A single dictionary with collated values. The numpy arrays, integers, and
-        torch tensors are stacked into torch tensors. All other types (including
-        list-valued fields such as multi-label lists) are kept as one list entry
-        per sample, unlike `torch.utils.data.default_collate`, which transposes
-        list-valued fields across the batch instead of preserving them per sample.
+        A single dictionary with collated values. The numpy arrays/scalars, booleans,
+        integers, floats, and torch tensors are stacked into torch tensors. All other
+        types (including list-valued fields such as multi-label lists) are kept as one
+        list entry per sample, unlike `torch.utils.data.default_collate`, which
+        transposes list-valued fields across the batch instead of preserving them per
+        sample.
     """
     value_list_dict = defaultdict(list)
     conversion_dict: dict[str, Callable[[Sequence[Any]], torch.Tensor]] = {}
@@ -141,8 +142,14 @@ def pxt_torch_dataset_collate_fn(batch: list[dict[str, Any]]) -> dict[str, Any]:
     def stack_arrays_and_convert_to_torch(arrays: Sequence[np.ndarray]) -> torch.Tensor:
         return torch.from_numpy(np.stack(arrays, axis=0))
 
+    def stack_bool_as_torch(bools: Sequence[bool]) -> torch.Tensor:
+        return torch.tensor(bools, dtype=torch.bool)
+
     def stack_int_as_torch(ints: Sequence[int]) -> torch.Tensor:
         return torch.tensor(ints, dtype=torch.int64)
+
+    def stack_float_as_torch(floats: Sequence[float]) -> torch.Tensor:
+        return torch.tensor(floats, dtype=torch.float64)
 
     def stack_tensors(tensors: Sequence[torch.Tensor]) -> torch.Tensor:
         return torch.stack(list(tensors), dim=0)
@@ -155,8 +162,14 @@ def pxt_torch_dataset_collate_fn(batch: list[dict[str, Any]]) -> dict[str, Any]:
                     conversion_dict[key] = stack_tensors
                 elif isinstance(value, np.ndarray):
                     conversion_dict[key] = stack_arrays_and_convert_to_torch
+                elif isinstance(value, np.generic):
+                    conversion_dict[key] = stack_arrays_and_convert_to_torch
+                elif isinstance(value, bool):
+                    conversion_dict[key] = stack_bool_as_torch
                 elif isinstance(value, int):
                     conversion_dict[key] = stack_int_as_torch
+                elif isinstance(value, float):
+                    conversion_dict[key] = stack_float_as_torch
 
     return {
         key: conversion_dict[key](value) if key in conversion_dict else value

--- a/goldener/pxt_utils.py
+++ b/goldener/pxt_utils.py
@@ -129,12 +129,8 @@ def pxt_torch_dataset_collate_fn(batch: list[dict[str, Any]]) -> dict[str, Any]:
         batch: A list of samples, where each sample is a dictionary.
 
     Returns:
-        A single dictionary with collated values. The numpy arrays/scalars, booleans,
-        integers, floats, and torch tensors are stacked into torch tensors. All other
-        types (including list-valued fields such as multi-label lists) are kept as one
-        list entry per sample, unlike `torch.utils.data.default_collate`, which
-        transposes list-valued fields across the batch instead of preserving them per
-        sample.
+        A single dictionary with collated values. The torch tensors, numpy arrays and
+        integers are stacked into torch tensors. All other types are kept as lists.
     """
     value_list_dict = defaultdict(list)
     conversion_dict: dict[str, Callable[[Sequence[Any]], torch.Tensor]] = {}
@@ -142,14 +138,8 @@ def pxt_torch_dataset_collate_fn(batch: list[dict[str, Any]]) -> dict[str, Any]:
     def stack_arrays_and_convert_to_torch(arrays: Sequence[np.ndarray]) -> torch.Tensor:
         return torch.from_numpy(np.stack(arrays, axis=0))
 
-    def stack_bool_as_torch(bools: Sequence[bool]) -> torch.Tensor:
-        return torch.tensor(bools, dtype=torch.bool)
-
     def stack_int_as_torch(ints: Sequence[int]) -> torch.Tensor:
         return torch.tensor(ints, dtype=torch.int64)
-
-    def stack_float_as_torch(floats: Sequence[float]) -> torch.Tensor:
-        return torch.tensor(floats, dtype=torch.float64)
 
     def stack_tensors(tensors: Sequence[torch.Tensor]) -> torch.Tensor:
         return torch.stack(list(tensors), dim=0)
@@ -162,14 +152,8 @@ def pxt_torch_dataset_collate_fn(batch: list[dict[str, Any]]) -> dict[str, Any]:
                     conversion_dict[key] = stack_tensors
                 elif isinstance(value, np.ndarray):
                     conversion_dict[key] = stack_arrays_and_convert_to_torch
-                elif isinstance(value, np.generic):
-                    conversion_dict[key] = stack_arrays_and_convert_to_torch
-                elif isinstance(value, bool):
-                    conversion_dict[key] = stack_bool_as_torch
                 elif isinstance(value, int):
                     conversion_dict[key] = stack_int_as_torch
-                elif isinstance(value, float):
-                    conversion_dict[key] = stack_float_as_torch
 
     return {
         key: conversion_dict[key](value) if key in conversion_dict else value

--- a/goldener/pxt_utils.py
+++ b/goldener/pxt_utils.py
@@ -129,8 +129,11 @@ def pxt_torch_dataset_collate_fn(batch: list[dict[str, Any]]) -> dict[str, Any]:
         batch: A list of samples, where each sample is a dictionary.
 
     Returns:
-        A single dictionary with collated values. The numpy arrays and integers
-        are stacked into torch tensors. All other types are kept as lists.
+        A single dictionary with collated values. The numpy arrays, integers, and
+        torch tensors are stacked into torch tensors. All other types (including
+        list-valued fields such as multi-label lists) are kept as one list entry
+        per sample, unlike `torch.utils.data.default_collate`, which transposes
+        list-valued fields across the batch instead of preserving them per sample.
     """
     value_list_dict = defaultdict(list)
     conversion_dict: dict[str, Callable[[Sequence[Any]], torch.Tensor]] = {}
@@ -141,11 +144,16 @@ def pxt_torch_dataset_collate_fn(batch: list[dict[str, Any]]) -> dict[str, Any]:
     def stack_int_as_torch(ints: Sequence[int]) -> torch.Tensor:
         return torch.tensor(ints, dtype=torch.int64)
 
+    def stack_tensors(tensors: Sequence[torch.Tensor]) -> torch.Tensor:
+        return torch.stack(list(tensors), dim=0)
+
     for idx_sample, sample in enumerate(batch):
         for key, value in sample.items():
             value_list_dict[key].append(value)
             if idx_sample == 0:
-                if isinstance(value, np.ndarray):
+                if isinstance(value, torch.Tensor):
+                    conversion_dict[key] = stack_tensors
+                elif isinstance(value, np.ndarray):
                     conversion_dict[key] = stack_arrays_and_convert_to_torch
                 elif isinstance(value, int):
                     conversion_dict[key] = stack_int_as_torch

--- a/goldener/select.py
+++ b/goldener/select.py
@@ -30,6 +30,7 @@ from goldener.pxt_utils import (
     make_batch_ready_for_table,
     check_pxt_table_has_primary_key,
     get_sample_row_from_idx,
+    pxt_torch_dataset_collate_fn,
 )
 from goldener.reduce import GoldReductionTool, GoldReductionToolWithFit
 from goldener.torch_utils import get_dataset_sample_dict
@@ -651,7 +652,8 @@ class GoldSelector:
         chunk: Optional chunk size for processing data in chunks to reduce memory consumption.
         collate_fn: Optional function to collate dataset samples into batches composed of
             dictionaries with at least the key specified by `vectorized_key` returning a PyTorch Tensor.
-            If None, the dataset is expected to directly provide such batches.
+            If None, `pxt_torch_dataset_collate_fn` is used, which preserves list-valued
+            fields as one list per sample.
         vectorized_key: Key in the batch dictionary that contains the vectorized data for selection. Default is "vectorized".
         include_vectorized_in_table: Whether to include the vectorized data in the selection table. Defaults to False.
         It is only applied if the cluster table is created from a Table (it is forced anyway for Dataset).
@@ -708,6 +710,7 @@ class GoldSelector:
             reducer: Optional GoldReductionTool instance for dimensionality reduction before selection.
             chunk: Optional chunk size for processing data in chunks.
             collate_fn: Optional collate function for the DataLoader.
+                If None, `pxt_torch_dataset_collate_fn` is used.
             vectorized_key: Key pointing to the vector for selection. Defaults to "vectorized".
             include_vectorized_in_table: Whether to include the vectorized data in the selection table. Defaults to False.
                 It is only applied if the selection table is created from a Table (it is forced anyway for Dataset).
@@ -731,7 +734,9 @@ class GoldSelector:
         self.selection_tool = selection_tool
         self.reducer = reducer
         self.chunk = chunk
-        self.collate_fn = collate_fn
+        self.collate_fn = (
+            collate_fn if collate_fn is not None else pxt_torch_dataset_collate_fn
+        )
         self.vectorized_key = vectorized_key
         self.include_vectorized_in_table = include_vectorized_in_table
         self.selection_key = selection_key
@@ -757,7 +762,6 @@ class GoldSelector:
         Args:
             select_from: Dataset or Table to select from. If a Dataset is provided, each item should be a
                 dictionary with at least the `vectorized_key` and `idx` keys after applying the collate_fn.
-                If the collate_fn is None, the dataset is expected to directly provide such batches.
                 If a Table is provided, it should contain at least the `vectorized_key`,
                 `idx` and `idx_vector` columns.
 
@@ -823,7 +827,6 @@ class GoldSelector:
         Args:
             select_from: Dataset or Table to select from. If a Dataset is provided, each item should be a
                 dictionary with at least the `vectorized_key` and `idx` keys after applying the collate_fn.
-                If the collate_fn is None, the dataset is expected to directly provide such batches.
                 If a Table is provided, it should contain at least the `vectorized_key`, `idx` and `idx_vector` columns.
             select_size: Number or ratio (between 0 and 1) of data points to select
             value: Value to set in the `selection_key` column for selected samples.
@@ -873,7 +876,6 @@ class GoldSelector:
         Args:
             select_from: Dataset or Table to select from. If a Dataset is provided, each item should be a
                 dictionary with at least the `vectorized_key` and `idx` keys after applying the collate_fn.
-                If the collate_fn is None, the dataset is expected to directly provide such batches.
                 If a Table is provided, it should contain at least the `vectorized_key`, `idx` and `idx_vector` columns.
             select_size: Number or ratio (between 0 and 1) of data points to select.
             value: Value to set in the `selection_key` column for selected samples.
@@ -1059,7 +1061,7 @@ class GoldSelector:
                 expected_keys=[self.vectorized_key],
             )
 
-            vectorized_value = sample[self.vectorized_key]
+            vectorized_value = sample[self.vectorized_key].squeeze(0)
             selection_table.add_column(
                 **{
                     self.vectorized_key: pxt.Array[  # type: ignore[misc]

--- a/goldener/split.py
+++ b/goldener/split.py
@@ -298,6 +298,7 @@ class GoldSplitter:
             num_workers: Number of workers to use when processing the input as dataset.
             collate_fn: Collate function to use when processing the input as dataset. It should
                 return a dictionary with at least the keys specified by `idx_key` and `selection_key`.
+                If None, `pxt_torch_dataset_collate_fn` is used.
 
         Returns:
             A dictionary mapping each set name to a set of sample indices.
@@ -310,7 +311,11 @@ class GoldSplitter:
                 split_data,
                 batch_size=batch_size,
                 num_workers=num_workers,
-                collate_fn=collate_fn,
+                collate_fn=(
+                    collate_fn
+                    if collate_fn is not None
+                    else pxt_torch_dataset_collate_fn
+                ),
             )
 
             for batch in dataloader:
@@ -360,7 +365,7 @@ class GoldSplitter:
         Args:
             to_split: Dataset or Table to be split. If a Dataset is provided, each item should be a
             dictionary with at least the key specified by descriptor `data_key` after applying the collate_fn.
-            If the collate_fn is None, the dataset is expected to directly provide such batches. If a Table is provided,
+            If a Table is provided,
             it should contain both 'idx' and `data_key` column for the descriptor.
 
         Returns:
@@ -395,7 +400,7 @@ class GoldSplitter:
         Args:
             to_split: Dataset or Table to be split. If a Dataset is provided, each item should be a
             dictionary with at least the key specified by descriptor `data_key` after applying the collate_fn.
-            If the collate_fn is None, the dataset is expected to directly provide such batches. If a Table is provided,
+            If a Table is provided,
             it should contain both 'idx' and `data_key` column for the descriptor.
 
         Returns:

--- a/goldener/vectorize.py
+++ b/goldener/vectorize.py
@@ -448,7 +448,8 @@ class GoldVectorizer:
         vectorizer: TensorVectorizer instance for transforming batched inputs into vectors.
         collate_fn: Optional function to collate dataset samples into batches composed of
             dictionaries with at least the key specified by `data_key` returning a PyTorch Tensor.
-            If None, the dataset is expected to directly provide such batches.
+            If None, `pxt_torch_dataset_collate_fn` is used, which preserves list-valued
+            fields as one list per sample.
         data_key: Key in the batch dictionary that contains the data to vectorize. Default is "embeddings".
         target_key: Optional key in the batch dictionary containing the target used to filter vectors. Default is "target".
         vectorized_key: Column name to store the resulting vectors in the PixelTable table. Default is "vectorized".
@@ -503,6 +504,7 @@ class GoldVectorizer:
             table_path: Path to the PixelTable table for storing vectors.
             vectorizer: TensorVectorizer instance for transforming tensors.
             collate_fn: Optional collate function for preparing batches.
+                If None, `pxt_torch_dataset_collate_fn` is used.
             data_key: Key for data in the batch dictionary. Defaults to "embeddings".
             target_key: Key for target in the batch dictionary. Defaults to "target".
             vectorized_key: Column name for storing vectors. Defaults to "vectorized".
@@ -523,7 +525,9 @@ class GoldVectorizer:
         """
         self.table_path = table_path
         self.vectorizer = vectorizer
-        self.collate_fn = collate_fn
+        self.collate_fn = (
+            collate_fn if collate_fn is not None else pxt_torch_dataset_collate_fn
+        )
         self.data_key = data_key
         self.target_key = target_key
         self.label_key = label_key
@@ -559,7 +563,7 @@ class GoldVectorizer:
         Args:
             to_vectorize: Dataset or Table to be vectorized. If a Dataset is provided, each item should be a
                 dictionary with at least the key specified by `data_key` after applying the collate_fn.
-                If the collate_fn is None, the dataset is expected to directly provide such batches. If a Table is provided,
+                If a Table is provided,
                 it should contain both 'idx' and `data_key` columns.
 
         Returns:
@@ -592,7 +596,7 @@ class GoldVectorizer:
         Args:
             to_vectorize: Dataset or Table to be vectorized. If a Dataset is provided, each item should be a
                 dictionary with at least the key specified by `data_key` after applying the collate_fn.
-                If the collate_fn is None, the dataset is expected to directly provide such batches. If a Table is provided,
+                If a Table is provided,
                 it should contain both 'idx' and `data_key` columns.
 
         Returns:

--- a/tests/test_clusterize.py
+++ b/tests/test_clusterize.py
@@ -11,7 +11,7 @@ from goldener.clusterize import (
     get_random_chunk_assignment,
 )
 from goldener.reduce import GoldSKLearnReductionTool
-from goldener.pxt_utils import GoldPxtTorchDataset
+from goldener.pxt_utils import GoldPxtTorchDataset, pxt_torch_dataset_collate_fn
 
 
 class DummyDataset(Dataset):
@@ -242,6 +242,23 @@ class TestGoldClusterizer:
 
     def teardown_method(self):
         pxt.drop_dir("unit_test", force=True)
+
+    def test_collate_fn_defaults_to_pxt_torch_dataset_collate_fn(self):
+        clusterizer = GoldClusterizer(
+            table_path="unit_test.cluster_default_collate",
+            clustering_tool=GoldRandomClusteringTool(),
+        )
+        assert clusterizer.collate_fn is pxt_torch_dataset_collate_fn
+
+        def custom_collate_fn(batch):
+            return batch
+
+        clusterizer = GoldClusterizer(
+            table_path="unit_test.cluster_default_collate",
+            clustering_tool=GoldRandomClusteringTool(),
+            collate_fn=custom_collate_fn,
+        )
+        assert clusterizer.collate_fn is custom_collate_fn
 
     def _make_src_table(self, path: str, n: int = 10, with_class: bool = False):
         source_rows = []

--- a/tests/test_describe.py
+++ b/tests/test_describe.py
@@ -718,6 +718,51 @@ class TestGoldDescriptor:
             assert row["idx"] in (0, 1)
             assert row["embeddings"].shape == (4,)
 
+    def test_describe_in_table_with_plain_multilabel_and_default_collate(
+        self, embedder, vectorizer
+    ):
+        """Regression test for #202.
+
+        When collate_fn is left at its default (None), PyTorch's own
+        default_collate transposes list-valued batch fields (like a
+        multi-label list) across the batch dimension instead of keeping
+        one list per sample. Each sample then silently loses all but one
+        of its labels.
+        """
+
+        class MultiLabelDataset:
+            def __len__(self):
+                return 2
+
+            def __getitem__(self, idx):
+                return {
+                    "data": torch.zeros(3, 8, 8),
+                    "idx": idx,
+                    "label": ["class_1", "class_2"],
+                }
+
+        desc = GoldDescriptor(
+            table_path="unit_test.test_describe_multilabel",
+            embedder=embedder,
+            vectorizer=vectorizer,
+            label_key="label",
+            to_keep_schema={"label": pxt.String},
+            batch_size=2,
+            collate_fn=None,
+            device=torch.device("cpu"),
+            allow_existing=False,
+            drop_table=True,
+        )
+
+        description = desc.describe_in_table(MultiLabelDataset())
+
+        labels_by_idx = defaultdict(set)
+        for row in description.collect():
+            labels_by_idx[row["idx"]].add(row["label"])
+
+        assert labels_by_idx[0] == {"class_1", "class_2"}
+        assert labels_by_idx[1] == {"class_1", "class_2"}
+
     def test_describe_in_table_after_restart_with_vectorizer(self, embedder):
         desc = GoldDescriptor(
             table_path="unit_test.test_describe",

--- a/tests/test_describe.py
+++ b/tests/test_describe.py
@@ -8,6 +8,7 @@ import pixeltable as pxt
 
 from goldener.describe import GoldDescriptor
 from goldener.embed import GoldTorchEmbeddingToolConfig, GoldTorchEmbeddingTool
+from goldener.pxt_utils import pxt_torch_dataset_collate_fn
 from goldener.vectorize import TensorVectorizer
 
 
@@ -762,6 +763,23 @@ class TestGoldDescriptor:
 
         assert labels_by_idx[0] == {"class_1", "class_2"}
         assert labels_by_idx[1] == {"class_1", "class_2"}
+
+    def test_collate_fn_defaults_to_pxt_torch_dataset_collate_fn(self, embedder):
+        desc = GoldDescriptor(
+            table_path="unit_test.test_describe",
+            embedder=embedder,
+        )
+        assert desc.collate_fn is pxt_torch_dataset_collate_fn
+
+        def custom_collate_fn(batch):
+            return batch
+
+        desc = GoldDescriptor(
+            table_path="unit_test.test_describe",
+            embedder=embedder,
+            collate_fn=custom_collate_fn,
+        )
+        assert desc.collate_fn is custom_collate_fn
 
     def test_describe_in_table_after_restart_with_vectorizer(self, embedder):
         desc = GoldDescriptor(

--- a/tests/test_pxt_utils.py
+++ b/tests/test_pxt_utils.py
@@ -223,6 +223,30 @@ class TestPxtTorchDatasetCollateFn:
         result = pxt_torch_dataset_collate_fn(batch)
         assert result == {}
 
+    def test_collate_booleans(self):
+        batch = [{"is_valid": True}, {"is_valid": False}]
+
+        result = pxt_torch_dataset_collate_fn(batch)
+
+        assert result["is_valid"].dtype == torch.bool
+        assert torch.equal(result["is_valid"], torch.tensor([True, False]))
+
+    def test_collate_floats(self):
+        batch = [{"score": 0.5}, {"score": 1.5}]
+
+        result = pxt_torch_dataset_collate_fn(batch)
+
+        assert result["score"].dtype == torch.float64
+        assert torch.equal(result["score"], torch.tensor([0.5, 1.5], dtype=torch.float64))
+
+    def test_collate_numpy_scalars(self):
+        batch = [{"value": np.float32(1.0)}, {"value": np.float32(2.0)}]
+
+        result = pxt_torch_dataset_collate_fn(batch)
+
+        assert result["value"].dtype == torch.float32
+        assert torch.equal(result["value"], torch.tensor([1.0, 2.0], dtype=torch.float32))
+
 
 class TestGetDistinctValueAndCountInColumn:
     def test_get_distinct_values(self):

--- a/tests/test_pxt_utils.py
+++ b/tests/test_pxt_utils.py
@@ -218,38 +218,31 @@ class TestPxtTorchDatasetCollateFn:
         assert result["image"].shape == (2, 3)
         assert torch.equal(result["label"], torch.tensor([0, 1], dtype=torch.int64))
 
+    def test_collate_tensors(self):
+        batch = [
+            {"data": torch.zeros(3, 4)},
+            {"data": torch.ones(3, 4)},
+        ]
+
+        result = pxt_torch_dataset_collate_fn(batch)
+
+        assert isinstance(result["data"], torch.Tensor)
+        assert result["data"].shape == (2, 3, 4)
+
+    def test_collate_keeps_multilabel_lists_per_sample(self):
+        batch = [
+            {"label": ["class_1", "class_2"]},
+            {"label": ["class_1", "class_2"]},
+        ]
+
+        result = pxt_torch_dataset_collate_fn(batch)
+
+        assert result["label"] == [["class_1", "class_2"], ["class_1", "class_2"]]
+
     def test_collate_empty_batch(self):
         batch = []
         result = pxt_torch_dataset_collate_fn(batch)
         assert result == {}
-
-    def test_collate_booleans(self):
-        batch = [{"is_valid": True}, {"is_valid": False}]
-
-        result = pxt_torch_dataset_collate_fn(batch)
-
-        assert result["is_valid"].dtype == torch.bool
-        assert torch.equal(result["is_valid"], torch.tensor([True, False]))
-
-    def test_collate_floats(self):
-        batch = [{"score": 0.5}, {"score": 1.5}]
-
-        result = pxt_torch_dataset_collate_fn(batch)
-
-        assert result["score"].dtype == torch.float64
-        assert torch.equal(
-            result["score"], torch.tensor([0.5, 1.5], dtype=torch.float64)
-        )
-
-    def test_collate_numpy_scalars(self):
-        batch = [{"value": np.float32(1.0)}, {"value": np.float32(2.0)}]
-
-        result = pxt_torch_dataset_collate_fn(batch)
-
-        assert result["value"].dtype == torch.float32
-        assert torch.equal(
-            result["value"], torch.tensor([1.0, 2.0], dtype=torch.float32)
-        )
 
 
 class TestGetDistinctValueAndCountInColumn:

--- a/tests/test_pxt_utils.py
+++ b/tests/test_pxt_utils.py
@@ -237,7 +237,9 @@ class TestPxtTorchDatasetCollateFn:
         result = pxt_torch_dataset_collate_fn(batch)
 
         assert result["score"].dtype == torch.float64
-        assert torch.equal(result["score"], torch.tensor([0.5, 1.5], dtype=torch.float64))
+        assert torch.equal(
+            result["score"], torch.tensor([0.5, 1.5], dtype=torch.float64)
+        )
 
     def test_collate_numpy_scalars(self):
         batch = [{"value": np.float32(1.0)}, {"value": np.float32(2.0)}]
@@ -245,7 +247,9 @@ class TestPxtTorchDatasetCollateFn:
         result = pxt_torch_dataset_collate_fn(batch)
 
         assert result["value"].dtype == torch.float32
-        assert torch.equal(result["value"], torch.tensor([1.0, 2.0], dtype=torch.float32))
+        assert torch.equal(
+            result["value"], torch.tensor([1.0, 2.0], dtype=torch.float32)
+        )
 
 
 class TestGetDistinctValueAndCountInColumn:

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -11,7 +11,7 @@ from sklearn.decomposition import PCA
 import pixeltable as pxt
 from torch.utils.data import Dataset
 
-from goldener.pxt_utils import GoldPxtTorchDataset
+from goldener.pxt_utils import GoldPxtTorchDataset, pxt_torch_dataset_collate_fn
 from goldener.reduce import GoldSKLearnReductionTool
 from goldener.select import (
     GoldSelector,
@@ -48,6 +48,19 @@ class TestGoldSelector:
 
     def teardown_method(self):
         pxt.drop_dir("unit_test", force=True)
+
+    def test_collate_fn_defaults_to_pxt_torch_dataset_collate_fn(self):
+        selector = GoldSelector(table_path="unit_test.select_default_collate")
+        assert selector.collate_fn is pxt_torch_dataset_collate_fn
+
+        def custom_collate_fn(batch):
+            return batch
+
+        selector = GoldSelector(
+            table_path="unit_test.select_default_collate",
+            collate_fn=custom_collate_fn,
+        )
+        assert selector.collate_fn is custom_collate_fn
 
     def test_selection_table_creation_from_table(self):
         src_path = "unit_test.src_table_input"

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -94,6 +94,22 @@ class TestGoldSplitter:
     def teardown_method(self):
         pxt.drop_dir("unit_test", force=True)
 
+    def test_get_split_indices_from_dataset_with_default_collate_fn(self):
+        splitted = GoldSplitter.get_split_indices(
+            DummyDataset(
+                [
+                    {"idx": 0, "selected": "train"},
+                    {"idx": 1, "selected": "val"},
+                    {"idx": 2, "selected": None},
+                ]
+            ),
+            selection_key="selected",
+            idx_key="idx",
+            batch_size=3,
+        )
+
+        assert splitted == {"train": {0}, "val": {1}}
+
     def test_split_in_table_from_dataset(self, basic_splitter):
         split_table = basic_splitter.split_in_table(
             to_split=DummyDataset(

--- a/tests/test_vectorize.py
+++ b/tests/test_vectorize.py
@@ -1,6 +1,7 @@
 import torch
 import pytest
 import pixeltable as pxt
+from goldener.pxt_utils import pxt_torch_dataset_collate_fn
 from goldener.vectorize import (
     TensorVectorizer,
     Filter2DWithCount,
@@ -389,6 +390,23 @@ class TestGoldVectorizer:
 
     def teardown_method(self):
         pxt.drop_dir("unit_test", force=True)
+
+    def test_collate_fn_defaults_to_pxt_torch_dataset_collate_fn(self):
+        gv = GoldVectorizer(
+            table_path="unit_test.vectorize_default_collate",
+            vectorizer=TensorVectorizer(),
+        )
+        assert gv.collate_fn is pxt_torch_dataset_collate_fn
+
+        def custom_collate_fn(batch):
+            return batch
+
+        gv = GoldVectorizer(
+            table_path="unit_test.vectorize_default_collate",
+            vectorizer=TensorVectorizer(),
+            collate_fn=custom_collate_fn,
+        )
+        assert gv.collate_fn is custom_collate_fn
 
     def test_vectorize_in_table_from_dataset(self):
         table_path = "unit_test.vectorize_from_dataset"

--- a/tests/test_vectorize.py
+++ b/tests/test_vectorize.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 import torch
 import pytest
 import pixeltable as pxt
@@ -407,6 +409,46 @@ class TestGoldVectorizer:
             collate_fn=custom_collate_fn,
         )
         assert gv.collate_fn is custom_collate_fn
+
+    def test_vectorize_in_table_with_plain_multilabel_and_default_collate(self):
+        """Regression test for #202 (GoldVectorizer flavor).
+
+        When collate_fn is left at its default (None), PyTorch's own
+        default_collate transposes list-valued batch fields (like a
+        multi-label list) across the batch dimension instead of keeping
+        one list per sample. Each sample then silently loses all but one
+        of its labels.
+        """
+
+        class MultiLabelDataset:
+            def __len__(self):
+                return 2
+
+            def __getitem__(self, idx):
+                return {
+                    "embeddings": torch.zeros(4, 3),
+                    "idx": idx,
+                    "label": ["class_1", "class_2"],
+                }
+
+        gv = GoldVectorizer(
+            table_path="unit_test.vectorize_multilabel",
+            vectorizer=TensorVectorizer(),
+            data_key="embeddings",
+            label_key="label",
+            to_keep_schema={"label": pxt.String},
+            batch_size=2,
+            allow_existing=False,
+        )
+
+        out_table = gv.vectorize_in_table(MultiLabelDataset())
+
+        labels_by_idx = defaultdict(set)
+        for row in out_table.collect():
+            labels_by_idx[row["idx"]].add(row["label"])
+
+        assert labels_by_idx[0] == {"class_1", "class_2"}
+        assert labels_by_idx[1] == {"class_1", "class_2"}
 
     def test_vectorize_in_table_from_dataset(self):
         table_path = "unit_test.vectorize_from_dataset"


### PR DESCRIPTION
Fixes #202. When collate_fn is left at its default (None), the
GoldDoers' DataLoaders fall through to PyTorch's own default_collate,
which transposes list-valued batch fields (e.g. a multi-label list)
across the batch dimension instead of keeping one list per sample.
Each sample silently loses all but one of its labels.

Fix (per the direction settled in #202): every GoldDoer's __init__ now
defaults collate_fn to pxt_torch_dataset_collate_fn when None —
GoldDescriptor, GoldVectorizer, GoldSelector, and GoldClusterizer —
and GoldSplitter.get_split_indices applies the same fallback for the
DataLoader it builds internally.

Companion fixes that this required:
- pxt_torch_dataset_collate_fn also stacks raw torch.Tensor, bool,
  float, and numpy-scalar values (previously only numpy.ndarray/int),
  since existing usage relies on tensor-valued fields with
  collate_fn=None.
- Sample-based schema inference now always goes through the collate,
  which adds a batch dimension — the clusterize/select inference sites
  missing a .squeeze(0) got one (select's dataset path already had it).

The simplification of the collate function itself (delegating to
torch's default_collate for non-sequence fields) is deliberately left
to #254.

Tests: regression test for the multi-label transposition (written
first, confirmed failing against the unfixed code), default-assignment
tests for all four GoldDoers, and a get_split_indices case with a None
selection value. Full suite: 423 passed; ruff + mypy clean.
