### PR TITLE
fix: type ResetableTorchIterableDataset._data_iterator as Optional

### DIFF
--- a/goldener/torch_utils.py
+++ b/goldener/torch_utils.py
@@ -1,4 +1,4 @@
-from typing import Callable, Any, TypeVar
+from typing import Callable, Any, Iterator, TypeVar
 
 import numpy as np
 import torch
@@ -130,7 +130,8 @@ class ResetableTorchIterableDataset(torch.utils.data.IterableDataset):
 
     Attributes:
         data_iterable: The underlying iterable dataset.
-        _data_iterator: The current iterator over the dataset.
+        _data_iterator: The current iterator over the dataset, or None once it
+            has been exhausted (see `__next__`) and not yet re-created.
     """
 
     def __init__(self, data_iterable: torch.utils.data.IterableDataset):
@@ -141,7 +142,7 @@ class ResetableTorchIterableDataset(torch.utils.data.IterableDataset):
         """
         super().__init__()
         self.data_iterable = data_iterable
-        self._data_iterator = iter(self.data_iterable)
+        self._data_iterator: Iterator[Any] | None = iter(self.data_iterable)
 
     def __iter__(self):
         """Return the iterator object."""
@@ -151,6 +152,10 @@ class ResetableTorchIterableDataset(torch.utils.data.IterableDataset):
 
     def __next__(self):
         """Return the next item from the iterator."""
+        # __iter__ always runs before __next__ in the iterator protocol and
+        # re-creates _data_iterator if it was exhausted, so it is never None
+        # here at runtime; the assert documents that invariant for mypy.
+        assert self._data_iterator is not None
         try:
             return next(self._data_iterator)
         except StopIteration:


### PR DESCRIPTION
mypy --check-untyped-defs flagged the is-None check in __iter__ as
unreachable, because _data_iterator's inferred type (from __init__)
was always Iterator[Any], never None. But __next__ deliberately sets
it to None on StopIteration so __iter__ knows to recreate it — this
is what lets a PyTorch DataLoader re-iterate the dataset across
multiple epochs.

Fixed the underlying type gap: annotated _data_iterator as
Iterator[Any] | None, matching its real runtime behavior. This
correctly surfaced a second error in __next__ (next() on a possibly-
None value), fixed with an assert that documents the actual invariant
(__iter__ always runs before __next__ and guarantees non-None) instead
of a blanket ignore.

Verified: mypy clean on the file, existing tests pass, directly tested
exhaust-then-reiterate (the exact scenario this design exists for),
full suite 414 passed, ruff clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the typing of `ResetableTorchIterableDataset` so `_data_iterator` can be `None`, matching runtime behavior and removing false positives from `mypy`. Keeps `torch` DataLoader re-iteration across epochs working as designed.

- **Bug Fixes**
  - Typed `_data_iterator` as `Iterator[Any] | None` and imported `Iterator`.
  - Added an assert in `__next__` to enforce the non-None invariant after `__iter__`.
  - Updated the attribute docstring to note the `None` state after exhaustion.

<sup>Written for commit de92695b7842376fc97fc0954b15e187ae262f4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/goldener-data/goldener/pull/251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

