### PR TITLE
docs: add README section for GoldClusterizedBatchSampler

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,14 +181,16 @@ When training with randomly sampled batches, the content distribution within eac
 some batches may end up overrepresenting certain types of data while barely including others. This imbalance 
 can hurt how well a model learns to recognize the underrepresented cases.
 
-Goldener's `GoldClusterizedBatchSampler` solves this by first clustering the data into groups of similar 
-content, then forcing every batch to include at least one sample from each cluster — ensuring balanced, 
-representative batches throughout training.
+Goldener's `GoldClusterizedBatchSampler` solves this by first clustering the data into groups of similar
+content, then drawing samples so each batch is spread across clusters as evenly as possible; when `n_clusters`
+is larger than `batch_size`, only a subset of clusters can appear in a given batch.
 
 ```python
 from goldener.organize import GoldClusterizedBatchSampler
-from goldener import GoldClusterizer, GoldSKLearnClusteringTool
+from goldener import GoldClusterizer, GoldDescriptor, GoldSKLearnClusteringTool
 from sklearn.cluster import KMeans
+
+gd = GoldDescriptor(...)  # reuse the descriptor used for smart sampling
 
 clusterizer = GoldClusterizer(
     table_path="my_table_for_clusterization",
@@ -197,9 +199,10 @@ clusterizer = GoldClusterizer(
 )
 
 batch_sampler = GoldClusterizedBatchSampler(
-    dataset=my_dataset,  # must already be vectorized unless descriptor/vectorizer are provided
+    dataset=my_dataset,
     batch_size=32,
     clusterizer=clusterizer,
+    descriptor=gd,
     n_clusters=10,
 )
 ```

--- a/README.md
+++ b/README.md
@@ -181,9 +181,7 @@ When training with randomly sampled batches, the content distribution within eac
 some batches may end up overrepresenting certain types of data while barely including others. This imbalance 
 can hurt how well a model learns to recognize the underrepresented cases.
 
-Goldener's `GoldClusterizedBatchSampler` solves this by first clustering the data into groups of similar
-content, then drawing samples so each batch is spread across clusters as evenly as possible; when `n_clusters`
-is larger than `batch_size`, only a subset of clusters can appear in a given batch.
+Goldener proposes a batch sampler grouping data into groups of similar content, and then drawing samples so each batch is spread across clusters as evenly as possible.
 
 ```python
 from goldener.organize import GoldClusterizedBatchSampler
@@ -191,17 +189,12 @@ from goldener import GoldClusterizer, GoldDescriptor, GoldSKLearnClusteringTool
 from sklearn.cluster import KMeans
 
 gd = GoldDescriptor(...)  # reuse the descriptor used for smart sampling
-
-clusterizer = GoldClusterizer(
-    table_path="my_table_for_clusterization",
-    clustering_tool=GoldSKLearnClusteringTool(KMeans(n_clusters=10)),
-    cluster_key="cluster",
-)
+gc = GoldClusterizer(...)  # reuse the clusterizer used for annotation guidelines
 
 batch_sampler = GoldClusterizedBatchSampler(
     dataset=my_dataset,
     batch_size=32,
-    clusterizer=clusterizer,
+    clusterizer=gc,
     descriptor=gd,
     n_clusters=10,
 )

--- a/README.md
+++ b/README.md
@@ -186,7 +186,8 @@ content, then forcing every batch to include at least one sample from each clust
 representative batches throughout training.
 
 ```python
-from goldener import GoldClusterizedBatchSampler, GoldClusterizer, GoldSKLearnClusteringTool
+from goldener.organize import GoldClusterizedBatchSampler
+from goldener import GoldClusterizer, GoldSKLearnClusteringTool
 from sklearn.cluster import KMeans
 
 clusterizer = GoldClusterizer(

--- a/README.md
+++ b/README.md
@@ -196,9 +196,10 @@ clusterizer = GoldClusterizer(
 )
 
 batch_sampler = GoldClusterizedBatchSampler(
-    dataset=my_dataset,
+    dataset=my_dataset,  # must already be vectorized unless descriptor/vectorizer are provided
     batch_size=32,
     clusterizer=clusterizer,
+    n_clusters=10,
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,33 @@ reducer = GoldSKLearnReductionTool(PCA(n_components=2))
 x_reduced = reducer.fit_transform(x)  # shape: (50, 2)
 ```
 
+## Balancing batches during training
+
+When training with randomly sampled batches, the content distribution within each batch can vary a lot — 
+some batches may end up overrepresenting certain types of data while barely including others. This imbalance 
+can hurt how well a model learns to recognize the underrepresented cases.
+
+Goldener's `GoldClusterizedBatchSampler` solves this by first clustering the data into groups of similar 
+content, then forcing every batch to include at least one sample from each cluster — ensuring balanced, 
+representative batches throughout training.
+
+```python
+from goldener import GoldClusterizedBatchSampler, GoldClusterizer, GoldSKLearnClusteringTool
+from sklearn.cluster import KMeans
+
+clusterizer = GoldClusterizer(
+    table_path="my_table_for_clusterization",
+    clustering_tool=GoldSKLearnClusteringTool(KMeans(n_clusters=10)),
+    cluster_key="cluster",
+)
+
+batch_sampler = GoldClusterizedBatchSampler(
+    dataset=my_dataset,
+    batch_size=32,
+    clusterizer=clusterizer,
+)
+```
+
 # Installation
 
 Installing Goldener is as simple as running the following command:


### PR DESCRIPTION
Added a README section for GoldClusterizedBatchSampler under "Example of features", explaining what problem it solves (imbalanced batches during training) and how it solves it (clustering + forced per-cluster representation), with a short usage example.

Fixes #255

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a README section on `GoldClusterizedBatchSampler` that explains how to balance training batches by clustering data and sampling across clusters. It includes a short example reusing `GoldClusterizer`, `GoldDescriptor`, and `GoldSKLearnClusteringTool` (with `KMeans`) and fixes #255.

<sup>Written for commit 760eb1936fdc4f432ad903256339af00c7c561d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/goldener-data/goldener/pull/256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

