### PR TITLE
test: standardize Pixeltable directory cleanup

### DIFF
--- a/tests/test_describe.py
+++ b/tests/test_describe.py
@@ -65,8 +65,14 @@ class DummyMultiSizeDataset:
 
 
 class TestGoldDescriptor:
-    def test_simple_describe_in_table(self, embedder):
+    def setup_method(self):
         pxt.drop_dir("unit_test", force=True)
+        pxt.create_dir("unit_test", if_exists="ignore")
+
+    def teardown_method(self):
+        pxt.drop_dir("unit_test", force=True)
+
+    def test_simple_describe_in_table(self, embedder):
         desc = GoldDescriptor(
             table_path="unit_test.test_describe",
             embedder=embedder,
@@ -84,11 +90,7 @@ class TestGoldDescriptor:
             assert row["embeddings"].shape == (4, 8, 8)
             assert row["label"] == "dummy"
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_describe_in_table_without_idx(self, embedder):
-        pxt.drop_dir("unit_test", force=True)
-
         def collate_fn(batch):
             data = torch.stack([b["data"] for b in batch], dim=0)
             return {"data": data}
@@ -110,11 +112,7 @@ class TestGoldDescriptor:
             assert row["idx"] == i
             assert row["embeddings"].shape == (4, 8, 8)
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_describe_in_table_with_non_dict_item(self, embedder):
-        pxt.drop_dir("unit_test", force=True)
-
         desc = GoldDescriptor(
             table_path="unit_test.test_describe",
             embedder=embedder,
@@ -125,11 +123,7 @@ class TestGoldDescriptor:
         with pytest.raises(ValueError, match="Sample must be a dictionary"):
             desc.describe_in_table(DummyDataset())
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_describe_in_table_with_missing_data_key(self, embedder):
-        pxt.drop_dir("unit_test", force=True)
-
         desc = GoldDescriptor(
             table_path="unit_test.test_describe",
             embedder=embedder,
@@ -142,11 +136,7 @@ class TestGoldDescriptor:
                 DummyDataset(),
             )
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_describe_in_table_with_collate_fn(self, embedder):
-        pxt.drop_dir("unit_test", force=True)
-
         def collate_fn(batch):
             data = torch.stack([b["data"] for b in batch], dim=0)
             idxs = [b["idx"] for b in batch]
@@ -178,11 +168,7 @@ class TestGoldDescriptor:
             elif col_name == "idx":
                 assert col_dict["type_"] == "Required[Int]"
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_describe_in_table_with_max_batches(self, embedder):
-        pxt.drop_dir("unit_test", force=True)
-
         desc = GoldDescriptor(
             table_path="unit_test.test_describe",
             embedder=embedder,
@@ -199,11 +185,7 @@ class TestGoldDescriptor:
         for i, row in enumerate(table.collect()):
             assert row["idx"] == i
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_describe_in_table_with_table_input(self, embedder):
-        pxt.drop_dir("unit_test", force=True)
-
         src_path = "unit_test.src_table_input"
         desc_path = "unit_test.test_describe_from_table"
 
@@ -212,7 +194,6 @@ class TestGoldDescriptor:
             {"idx": 1, "data": torch.zeros(3, 8, 8).numpy(), "label": "dummy"},
         ]
 
-        pxt.create_dir("unit_test", if_exists="ignore")
         src_table = pxt.create_table(
             src_path, source=source_rows, if_exists="replace_force"
         )
@@ -236,11 +217,7 @@ class TestGoldDescriptor:
             assert row["embeddings"].shape == (4, 8, 8)
             assert row["label"] == "dummy"
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_describe_in_table_after_restart(self, embedder):
-        pxt.drop_dir("unit_test", force=True)
-
         desc = GoldDescriptor(
             table_path="unit_test.test_describe",
             embedder=embedder,
@@ -264,11 +241,7 @@ class TestGoldDescriptor:
             assert row["idx"] == i
             assert row["embeddings"].shape == (4, 8, 8)
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_describe_in_table_after_restart_with_restart_disallowed(self, embedder):
-        pxt.drop_dir("unit_test", force=True)
-
         desc = GoldDescriptor(
             table_path="unit_test.test_describe",
             embedder=embedder,
@@ -286,11 +259,7 @@ class TestGoldDescriptor:
         ):
             desc.describe_in_table(dataset)
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_describe_in_dataset(self, embedder):
-        pxt.drop_dir("unit_test", force=True)
-
         desc = GoldDescriptor(
             table_path="unit_test.test_describe",
             embedder=embedder,
@@ -309,11 +278,7 @@ class TestGoldDescriptor:
 
         dataset.keep_cache = False
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_describe_in_dataset_from_table(self, embedder):
-        pxt.drop_dir("unit_test", force=True)
-
         src_path = "unit_test.src_table_input"
 
         source_rows = [
@@ -321,7 +286,6 @@ class TestGoldDescriptor:
             {"idx": 1, "data": torch.zeros(3, 8, 8).numpy(), "label": "dummy"},
         ]
 
-        pxt.create_dir("unit_test", if_exists="ignore")
         src_table = pxt.create_table(
             src_path, source=source_rows, if_exists="replace_force"
         )
@@ -344,13 +308,9 @@ class TestGoldDescriptor:
 
         dataset.keep_cache = False
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_simple_describe_in_table_from_dataset_with_target(
         self, embedder, vectorizer
     ):
-        pxt.drop_dir("unit_test", force=True)
-
         desc = GoldDescriptor(
             table_path="unit_test.test_describe",
             embedder=embedder,
@@ -369,13 +329,9 @@ class TestGoldDescriptor:
             assert row["embeddings"].shape == (4,)
             assert row["label"] == "dummy"
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_simple_describe_in_table_from_dataset_with_target_and_collatefn(
         self, embedder, vectorizer
     ):
-        pxt.drop_dir("unit_test", force=True)
-
         def collate_fn(batch):
             data = torch.stack([b["data"] for b in batch], dim=0)
             idxs = [b["idx"] for b in batch]
@@ -401,10 +357,7 @@ class TestGoldDescriptor:
             assert row["embeddings"].shape == (4,)
             assert row["label"] == "dummy"
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_describe_in_table_from_table_with_vectorizer(self, embedder, vectorizer):
-        pxt.drop_dir("unit_test", force=True)
         desc = GoldDescriptor(
             table_path="unit_test.test_describe",
             embedder=embedder,
@@ -425,11 +378,7 @@ class TestGoldDescriptor:
 
         assert set([row["idx"] for row in table.collect()]) == {0, 1}
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_describe_in_dataset_from_table_with_vectorizer(self, embedder, vectorizer):
-        pxt.drop_dir("unit_test", force=True)
-
         src_path = "unit_test.src_table_input"
 
         source_rows = [
@@ -437,7 +386,6 @@ class TestGoldDescriptor:
             {"idx": 1, "data": torch.zeros(3, 8, 8).numpy(), "label": "dummy"},
         ]
 
-        pxt.create_dir("unit_test", if_exists="ignore")
         src_table = pxt.create_table(
             src_path, source=source_rows, if_exists="replace_force"
         )
@@ -461,13 +409,9 @@ class TestGoldDescriptor:
 
         dataset.keep_cache = False
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_describe_in_dataset_from_table_with_vectorizer_and_target(
         self, embedder, vectorizer
     ):
-        pxt.drop_dir("unit_test", force=True)
-
         src_path = "unit_test.src_table_input"
 
         source_rows = [
@@ -485,7 +429,6 @@ class TestGoldDescriptor:
             },
         ]
 
-        pxt.create_dir("unit_test", if_exists="ignore")
         src_table = pxt.create_table(
             src_path, source=source_rows, if_exists="replace_force"
         )
@@ -509,13 +452,9 @@ class TestGoldDescriptor:
 
         dataset.keep_cache = False
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_describe_in_dataset_from_table_with_excluded_label(
         self, embedder, vectorizer
     ):
-        pxt.drop_dir("unit_test", force=True)
-
         src_path = "unit_test.src_table_input"
 
         source_rows = [
@@ -533,7 +472,6 @@ class TestGoldDescriptor:
             },
         ]
 
-        pxt.create_dir("unit_test", if_exists="ignore")
         src_table = pxt.create_table(
             src_path, source=source_rows, if_exists="replace_force"
         )
@@ -560,19 +498,14 @@ class TestGoldDescriptor:
 
         dataset.keep_cache = False
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_describe_in_dataset_from_table_with_vectorizer_and_multitarget(
         self, embedder, vectorizer
     ):
-        pxt.drop_dir("unit_test", force=True)
-
         src_path = "unit_test.src_table_input"
 
         target = torch.zeros(1, 8, 8).numpy()
         target[0, 0, 0] = 25
 
-        pxt.create_dir("unit_test", if_exists="ignore")
         src_table = pxt.create_table(
             src_path,
             schema={
@@ -649,19 +582,14 @@ class TestGoldDescriptor:
             assert row["embeddings"].shape == (4,)
             assert row["label"] in ("class_1", "class_2")
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_describe_in_dataset_from_table_with_vectorizer_and_merge_multilabel(
         self, embedder, vectorizer
     ):
-        pxt.drop_dir("unit_test", force=True)
-
         src_path = "unit_test.src_table_input"
 
         target = torch.zeros(1, 8, 8).numpy()
         target[0, 0, 0] = 25
 
-        pxt.create_dir("unit_test", if_exists="ignore")
         src_table = pxt.create_table(
             src_path,
             schema={
@@ -739,13 +667,9 @@ class TestGoldDescriptor:
             assert row["embeddings"].shape == (4,)
             assert row["label"] == "class_1_class_2"
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_describe_in_dataset_from_table_with_vectorizer_and_multitarget_without_zeros(
         self, embedder, vectorizer
     ):
-        pxt.drop_dir("unit_test", force=True)
-
         src_path = "unit_test.src_table_input"
 
         target = torch.zeros(1, 8, 8).numpy()
@@ -770,7 +694,6 @@ class TestGoldDescriptor:
             },
         ]
 
-        pxt.create_dir("unit_test", if_exists="ignore")
         src_table = pxt.create_table(
             src_path, source=source_rows, if_exists="replace_force"
         )
@@ -795,11 +718,7 @@ class TestGoldDescriptor:
             assert row["idx"] in (0, 1)
             assert row["embeddings"].shape == (4,)
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_describe_in_table_after_restart_with_vectorizer(self, embedder):
-        pxt.drop_dir("unit_test", force=True)
-
         desc = GoldDescriptor(
             table_path="unit_test.test_describe",
             embedder=embedder,
@@ -824,10 +743,7 @@ class TestGoldDescriptor:
             assert row["idx_vector"] == i
             assert row["embeddings"].shape == (4,)
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_describe_with_force_fix_description_false(self, embedder):
-        pxt.drop_dir("unit_test", force=True)
         desc = GoldDescriptor(
             table_path="unit_test.test_describe",
             embedder=embedder,
@@ -841,5 +757,3 @@ class TestGoldDescriptor:
         assert table.count() == 2
         rows = table.collect()
         assert rows[0]["embeddings"].shape != rows[1]["embeddings"].shape
-
-        pxt.drop_dir("unit_test", force=True)

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -42,9 +42,14 @@ class DummyDataset(Dataset):
 
 
 class TestGoldSelector:
-    def test_selection_table_creation_from_table(self):
+    def setup_method(self):
+        pxt.drop_dir("unit_test", force=True)
+        pxt.create_dir("unit_test", if_exists="ignore")
+
+    def teardown_method(self):
         pxt.drop_dir("unit_test", force=True)
 
+    def test_selection_table_creation_from_table(self):
         src_path = "unit_test.src_table_input"
         desc_path = "unit_test.test_select_from_table"
 
@@ -63,7 +68,6 @@ class TestGoldSelector:
             },
         ]
 
-        pxt.create_dir("unit_test", if_exists="ignore")
         src_table = pxt.create_table(
             src_path, source=source_rows, if_exists="replace_force"
         )
@@ -85,14 +89,8 @@ class TestGoldSelector:
         ]
         assert set(row_indices) == {0, 1}
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_selection_table_from_table_when_missing_vectorized(self):
-        pxt.drop_dir("unit_test", force=True)
-
         src_path = "unit_test.src_table_invalid"
-        pxt.create_dir("unit_test", if_exists="ignore")
-
         src_table = pxt.create_table(
             src_path,
             source=[{"idx": 0, "notvec": [1, 2, 3]}],
@@ -106,14 +104,8 @@ class TestGoldSelector:
                 select_from=src_table, old_selection_table=None
             )
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_selection_table_from_table_when_invalid_old(self):
-        pxt.drop_dir("unit_test", force=True)
-
         src_path = "unit_test.src_table_invalid"
-        pxt.create_dir("unit_test", if_exists="ignore")
-
         src_table = pxt.create_table(
             src_path,
             source=[
@@ -131,11 +123,7 @@ class TestGoldSelector:
                 select_from=src_table, old_selection_table=src_table
             )
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_selection_table_from_dataset(self):
-        pxt.drop_dir("unit_test", force=True)
-
         table_path = "unit_test.test_select_initialize"
 
         sample = {
@@ -162,11 +150,7 @@ class TestGoldSelector:
         ]
         assert set(row_indices) == {0, 1}
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_select_in_table_from_dataset(self):
-        pxt.drop_dir("unit_test", force=True)
-
         table_path = "unit_test.test_select_from_dataset"
 
         dataset = DummyDataset(
@@ -192,11 +176,7 @@ class TestGoldSelector:
         # validate running with already filled work
         selector.select_in_table(dataset, select_size=10, value="train")
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_select_in_table_with_new_idx_vector(self):
-        pxt.drop_dir("unit_test", force=True)
-
         table_path = "unit_test.test_select_from_dataset"
 
         dataset = DummyDataset(
@@ -234,11 +214,7 @@ class TestGoldSelector:
         assert len(selected_indices_2) == 20
         assert selected_indices_1.issubset(selected_indices_2)
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_select_in_table_with_wrong_size(self):
-        pxt.drop_dir("unit_test", force=True)
-
         table_path = "unit_test.test_select_from_dataset"
 
         dataset = DummyDataset(
@@ -257,11 +233,7 @@ class TestGoldSelector:
         with pytest.raises(ValueError, match="select_size must be a positive integer"):
             selector.select_in_table(dataset, select_size=0, value="train")
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_select_in_table_from_dataset_with_ratio(self):
-        pxt.drop_dir("unit_test", force=True)
-
         table_path = "unit_test.test_select_from_dataset"
 
         dataset = DummyDataset(
@@ -284,11 +256,7 @@ class TestGoldSelector:
             == 10
         )
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_select_in_table_from_dataset_with_small_ratio(self):
-        pxt.drop_dir("unit_test", force=True)
-
         table_path = "unit_test.test_select_from_dataset"
 
         dataset = DummyDataset(
@@ -311,11 +279,7 @@ class TestGoldSelector:
             == 1
         )
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_select_in_table_from_dataset_with_class(self):
-        pxt.drop_dir("unit_test", force=True)
-
         table_path = "unit_test.test_select_from_dataset"
 
         dataset = DummyDataset(
@@ -370,11 +334,7 @@ class TestGoldSelector:
             == 50
         )
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_select_in_table_from_dataset_with_excluded_labels(self):
-        pxt.drop_dir("unit_test", force=True)
-
         table_path = "unit_test.test_select_from_dataset"
 
         dataset = DummyDataset(
@@ -407,8 +367,6 @@ class TestGoldSelector:
         for row in selection_table.collect():
             assert row["label"] == "kept"
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_select_with_exclude_labels_without_label_key_raises(self):
         with pytest.raises(
             ValueError,
@@ -420,8 +378,6 @@ class TestGoldSelector:
             )
 
     def test_select_in_table_with_chunk(self):
-        pxt.drop_dir("unit_test", force=True)
-
         table_path = "unit_test.test_select_chunk"
 
         dataset = DummyDataset(
@@ -452,11 +408,7 @@ class TestGoldSelector:
             == 10
         )
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_select_in_table_with_reducer(self):
-        pxt.drop_dir("unit_test", force=True)
-
         table_path = "unit_test.test_select_reducer"
 
         dataset = DummyDataset(
@@ -482,11 +434,7 @@ class TestGoldSelector:
             == 10
         )
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_select_in_table_with_max_batches(self):
-        pxt.drop_dir("unit_test", force=True)
-
         table_path = "unit_test.test_select_max_batches"
 
         dataset = DummyDataset(
@@ -509,11 +457,7 @@ class TestGoldSelector:
             == 10
         )
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_select_in_table_with_restart_and_reducer(self):
-        pxt.drop_dir("unit_test", force=True)
-
         table_path = "unit_test.test_select_max_batches"
 
         dataset = DummyDataset(
@@ -543,11 +487,7 @@ class TestGoldSelector:
             == 20
         )
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_select_in_table_with_restart(self):
-        pxt.drop_dir("unit_test", force=True)
-
         table_path = "unit_test.test_select_max_batches"
 
         dataset = DummyDataset(
@@ -573,11 +513,7 @@ class TestGoldSelector:
             == 20
         )
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_select_in_table_with_restart_disallowed(self):
-        pxt.drop_dir("unit_test", force=True)
-
         table_path = "unit_test.test_select_max_batches"
 
         dataset = DummyDataset(
@@ -598,11 +534,7 @@ class TestGoldSelector:
         ):
             selector.select_in_table(dataset, select_size=20, value="train")
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_select_in_table_with_not_enough_sample(self):
-        pxt.drop_dir("unit_test", force=True)
-
         table_path = "unit_test.test_select_not_enough"
         dataset = DummyDataset(
             [{"vectorized": torch.rand(5), "idx": idx} for idx in range(100)]
@@ -618,14 +550,9 @@ class TestGoldSelector:
         ):
             selector.select_in_table(dataset, select_size=21, value="train")
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_select_in_table_from_table(self):
-        pxt.drop_dir("unit_test", force=True)
-
         src_path = "unit_test.test_select_in_table"
 
-        pxt.create_dir("unit_test", if_exists="ignore")
         src_table = pxt.create_table(
             src_path,
             source=[
@@ -664,14 +591,9 @@ class TestGoldSelector:
             == 6
         )
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_select_in_table_from_table_with_vectorized_included(self):
-        pxt.drop_dir("unit_test", force=True)
-
         src_path = "unit_test.test_select_in_table"
 
-        pxt.create_dir("unit_test", if_exists="ignore")
         src_table = pxt.create_table(
             src_path,
             source=[
@@ -708,11 +630,7 @@ class TestGoldSelector:
             == 6
         )
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_select_in_dataset_from_dataset(self):
-        pxt.drop_dir("unit_test", force=True)
-
         table_path = "unit_test.test_select_from_dataset"
 
         dataset = DummyDataset(
@@ -741,11 +659,7 @@ class TestGoldSelector:
 
         dataset.keep_cache = False
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_select_in_table_from_dataset_with_already_selected(self):
-        pxt.drop_dir("unit_test", force=True)
-
         table_path = "unit_test.test_select_from_dataset"
 
         dataset = DummyDataset(
@@ -769,11 +683,7 @@ class TestGoldSelector:
         ):
             selector.select_in_table(dataset, select_size=15, value="train")
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_select_in_dataset_with_drop_table(self):
-        pxt.drop_dir("unit_test", force=True)
-
         table_path = "unit_test.test_select_from_dataset"
 
         dataset = DummyDataset(
@@ -798,14 +708,9 @@ class TestGoldSelector:
 
         dataset.keep_cache = False
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_get_selected_indices(self):
-        pxt.drop_dir("unit_test", force=True)
-
         src_path = "unit_test.test_select"
 
-        pxt.create_dir("unit_test", if_exists="ignore")
         src_table = pxt.create_table(
             src_path,
             source=[
@@ -877,8 +782,6 @@ class TestGoldSelector:
                 label_key=None,
                 label_value="other",
             )
-
-        pxt.drop_dir("unit_test", force=True)
 
 
 class TestGoldGreedyClosestPointSelectionTool:

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -87,9 +87,14 @@ def basic_splitter(descriptor, vectorizer, selector):
 
 
 class TestGoldSplitter:
-    def test_split_in_table_from_dataset(self, basic_splitter):
+    def setup_method(self):
+        pxt.drop_dir("unit_test", force=True)
+        pxt.create_dir("unit_test", if_exists="ignore")
+
+    def teardown_method(self):
         pxt.drop_dir("unit_test", force=True)
 
+    def test_split_in_table_from_dataset(self, basic_splitter):
         split_table = basic_splitter.split_in_table(
             to_split=DummyDataset(
                 [
@@ -113,13 +118,8 @@ class TestGoldSplitter:
         pxt.get_table(basic_splitter.vectorizer.table_path)
         pxt.get_table(basic_splitter.selector.table_path)
 
-        pxt.drop_dir("unit_test", if_not_exists="ignore", force=True)
-
     def test_split_in_table_from_table(self, basic_splitter):
-        pxt.drop_dir("unit_test", force=True)
-
         src_path = "unit_test.test_split_in_table"
-        pxt.create_dir("unit_test", if_exists="ignore")
         src_table = pxt.create_table(
             src_path,
             source=[
@@ -145,11 +145,7 @@ class TestGoldSplitter:
         assert len(splitted["train"]) == 5
         assert len(splitted["val"]) == 5
 
-        pxt.drop_dir("unit_test", if_not_exists="ignore", force=True)
-
     def test_split_with_label(self, descriptor, selector, vectorizer):
-        pxt.drop_dir("unit_test", force=True)
-
         sets = [
             GoldSet(name="train", size=0.5),
             GoldSet(name="val", size=0.5),
@@ -180,11 +176,7 @@ class TestGoldSplitter:
         assert len(splitted["train"]) == 5
         assert len(splitted["val"]) == 5
 
-        pxt.drop_dir("unit_test", if_not_exists="ignore", force=True)
-
     def test_split_with_excluded_labels(self, descriptor, vectorizer, embedder):
-        pxt.drop_dir("unit_test", force=True)
-
         sets = [
             GoldSet(name="train", size=0.5),
             GoldSet(name="val", size=0.5),
@@ -230,11 +222,7 @@ class TestGoldSplitter:
         # Only 6 samples (idx 4-9) remain after excluding idx 0-3
         assert len(splitted["train"]) + len(splitted["val"]) == 6
 
-        pxt.drop_dir("unit_test", if_not_exists="ignore", force=True)
-
     def test_duplicated_set_names(self, descriptor, selector, vectorizer):
-        pxt.drop_dir("unit_test", force=True)
-
         sets = [GoldSet(name="train", size=0.5), GoldSet(name="train", size=0.5)]
         with pytest.raises(ValueError, match="Set names must be unique"):
             GoldSplitter(
@@ -244,11 +232,7 @@ class TestGoldSplitter:
                 vectorizer=vectorizer,
             )
 
-        pxt.drop_dir("unit_test", if_not_exists="ignore", force=True)
-
     def test_not_complete_set_sizes_as_float(self, descriptor, selector, vectorizer):
-        pxt.drop_dir("unit_test", force=True)
-
         with pytest.raises(
             ValueError, match="Sampling size as float must be equal to 1.0"
         ):
@@ -259,11 +243,7 @@ class TestGoldSplitter:
                 vectorizer=vectorizer,
             )
 
-        pxt.drop_dir("unit_test", if_not_exists="ignore", force=True)
-
     def test_not_complete_set_sizes_as_int(self, descriptor, selector, vectorizer):
-        pxt.drop_dir("unit_test", force=True)
-
         gold_splitter = GoldSplitter(
             sets=[GoldSet(name="train", size=2), GoldSet(name="val", size=2)],
             descriptor=descriptor,
@@ -284,11 +264,7 @@ class TestGoldSplitter:
                 )
             )
 
-        pxt.drop_dir("unit_test", if_not_exists="ignore", force=True)
-
     def test_different_type_set_size(self, descriptor, selector, vectorizer):
-        pxt.drop_dir("unit_test", force=True)
-
         with pytest.raises(ValueError, match="All set sizes must be of the same type"):
             GoldSplitter(
                 sets=[GoldSet(name="train", size=0.5), GoldSet(name="val", size=3)],
@@ -297,10 +273,7 @@ class TestGoldSplitter:
                 vectorizer=vectorizer,
             )
 
-        pxt.drop_dir("unit_test", if_not_exists="ignore", force=True)
-
     def test_label_key_not_found(self, descriptor, selector, vectorizer):
-        pxt.drop_dir("unit_test", force=True)
         selector.label_key = "nonexistent"
         sets = [
             GoldSet(name="train", size=0.5),
@@ -325,11 +298,7 @@ class TestGoldSplitter:
                 )
             )
 
-        pxt.drop_dir("unit_test", if_not_exists="ignore", force=True)
-
     def test_set_with_small_population(self, descriptor, selector, vectorizer):
-        pxt.drop_dir("unit_test", force=True)
-
         sets = [
             GoldSet(name="train", size=0.001),
             GoldSet(name="val", size=0.999),
@@ -356,12 +325,9 @@ class TestGoldSplitter:
         assert set(splitted.keys()) == {"train", "val"}
         assert len(splitted["train"]) == 1
 
-        pxt.drop_dir("unit_test", if_not_exists="ignore", force=True)
-
     def test_class_with_small_population_failure(
         self, descriptor, selector, vectorizer
     ):
-        pxt.drop_dir("unit_test", force=True)
         selector.label_key = "label"
         sets = [
             GoldSet(name="train", size=0.0001),
@@ -388,11 +354,7 @@ class TestGoldSplitter:
                 )
             )
 
-        pxt.drop_dir("unit_test", if_not_exists="ignore", force=True)
-
     def test_max_batches(self, descriptor, selector, vectorizer):
-        pxt.drop_dir("unit_test", force=True)
-
         sets = [GoldSet(name="train", size=0.5), GoldSet(name="val", size=0.5)]
         splitter = GoldSplitter(
             sets=sets,
@@ -422,11 +384,7 @@ class TestGoldSplitter:
         # Only 2 items total (1 batch with batch_size=2)
         assert len(splitted["train"]) + len(splitted["val"]) == 2
 
-        pxt.drop_dir("unit_test", if_not_exists="ignore", force=True)
-
     def test_with_no_remaining_indices(self, descriptor, selector, vectorizer):
-        pxt.drop_dir("unit_test", force=True)
-
         sets = [GoldSet(name="train", size=0.5), GoldSet(name="val", size=0.5)]
         selector.max_batches = 1
         vectorizer.max_batches = 1
@@ -451,10 +409,7 @@ class TestGoldSplitter:
                 )
             )
 
-        pxt.drop_dir("unit_test", if_not_exists="ignore", force=True)
-
     def test_split_in_dataset_from_dataset(self, basic_splitter):
-        pxt.drop_dir("unit_test", force=True)
         basic_splitter.in_described_table = True
         basic_splitter.drop_table = True
         split_dataset = basic_splitter.split_in_dataset(
@@ -494,10 +449,7 @@ class TestGoldSplitter:
 
         split_dataset.keep_cache = False
 
-        pxt.drop_dir("unit_test", if_not_exists="ignore", force=True)
-
     def test_split_in_dataset_without_drop(self, basic_splitter):
-        pxt.drop_dir("unit_test", force=True)
         basic_splitter.in_described_table = True
         basic_splitter.drop_table = False
         split_dataset = basic_splitter.split_in_dataset(
@@ -524,11 +476,7 @@ class TestGoldSplitter:
 
         split_dataset.keep_cache = False
 
-        pxt.drop_dir("unit_test", if_not_exists="ignore", force=True)
-
     def test_split_in_table_from_dataset_with_drop_table(self, basic_splitter):
-        pxt.drop_dir("unit_test", force=True)
-
         basic_splitter.drop_table = True
         basic_splitter.split_in_table(
             to_split=DummyDataset(
@@ -561,11 +509,7 @@ class TestGoldSplitter:
         with pytest.raises(pxt.Error):
             pxt.get_table(basic_splitter.vectorizer.table_path)
 
-        pxt.drop_dir("unit_test", if_not_exists="ignore", force=True)
-
     def test_split_in_table_from_dataset_with_restart(self, basic_splitter):
-        pxt.drop_dir("unit_test", force=True)
-
         dataset = DummyDataset(
             [
                 {"data": torch.rand(3, 8, 8), "idx": idx, "label": "dummy"}
@@ -590,13 +534,8 @@ class TestGoldSplitter:
         assert len(splitted["train"]) == 5
         assert len(splitted["val"]) == 5
 
-        pxt.drop_dir("unit_test", if_not_exists="ignore", force=True)
-
     def test_get_split_indices_from_table(self):
-        pxt.drop_dir("unit_test", force=True)
-
         src_path = "unit_test.test_split_in_table"
-        pxt.create_dir("unit_test", if_exists="ignore")
         split_table = pxt.create_table(
             src_path,
             source=[
@@ -621,11 +560,7 @@ class TestGoldSplitter:
             assert len(indices) == 5
             assert set_name in ["train", "val"]
 
-        pxt.drop_dir("unit_test", if_not_exists="ignore", force=True)
-
     def test_get_split_indices_from_dataset(self):
-        pxt.drop_dir("unit_test", force=True)
-
         split_dataset = DummyDataset(
             [
                 {
@@ -648,11 +583,7 @@ class TestGoldSplitter:
             assert len(indices) == 5
             assert set_name in ["train", "val"]
 
-        pxt.drop_dir("unit_test", if_not_exists="ignore", force=True)
-
     def test_with_descriptor_including_vectorizer(self, embedder):
-        pxt.drop_dir("unit_test", force=True)
-
         descriptor = GoldDescriptor(
             table_path="unit_test.descriptor_split",
             embedder=embedder,
@@ -699,11 +630,7 @@ class TestGoldSplitter:
         # Only 2 items total (1 batch with batch_size=2)
         assert len(splitted["train"]) + len(splitted["val"]) == 2
 
-        pxt.drop_dir("unit_test", if_not_exists="ignore", force=True)
-
     def test_without_descriptor(self, basic_splitter):
-        pxt.drop_dir("unit_test", force=True)
-
         basic_splitter.descriptor = None
         basic_splitter.vectorizer.collate_fn = None
         split_table = basic_splitter.split_in_table(
@@ -724,11 +651,7 @@ class TestGoldSplitter:
         # Only 2 items total (1 batch with batch_size=2)
         assert len(splitted["train"]) + len(splitted["val"]) == 10
 
-        pxt.drop_dir("unit_test", if_not_exists="ignore", force=True)
-
     def test_without_descriptor_nor_vectorizer(self, basic_splitter):
-        pxt.drop_dir("unit_test", force=True)
-
         basic_splitter.descriptor = None
         basic_splitter.vectorizer = None
         split_table = basic_splitter.split_in_table(
@@ -755,11 +678,7 @@ class TestGoldSplitter:
         # Only 2 items total (1 batch with batch_size=2)
         assert len(splitted["train"]) + len(splitted["val"]) == 10
 
-        pxt.drop_dir("unit_test", if_not_exists="ignore", force=True)
-
     def test_with_int_sizes(self, basic_splitter):
-        pxt.drop_dir("unit_test", force=True)
-
         basic_splitter.descriptor = None
         basic_splitter.vectorizer = None
         basic_splitter.sets = [
@@ -789,11 +708,7 @@ class TestGoldSplitter:
         assert len(splitted) == 2
         assert len(splitted["train"]) + len(splitted["val"]) == 10
 
-        pxt.drop_dir("unit_test", if_not_exists="ignore", force=True)
-
     def test_with_no_descriptor_but_in_described_table(self, selector):
-        pxt.drop_dir("unit_test", force=True)
-
         with pytest.raises(
             ValueError,
             match="in_described_table is set to True, but no descriptor is provided",
@@ -806,11 +721,7 @@ class TestGoldSplitter:
                 in_described_table=True,
             )
 
-        pxt.drop_dir("unit_test", if_not_exists="ignore", force=True)
-
     def test_with_vectorizer_but_wrong_selection_key(self, selector, vectorizer):
-        pxt.drop_dir("unit_test", force=True)
-
         vectorizer.vectorized_key = "wrong_key"
         with pytest.raises(
             ValueError, match="does not match selector's vectorized_key"
@@ -823,11 +734,7 @@ class TestGoldSplitter:
                 in_described_table=False,
             )
 
-        pxt.drop_dir("unit_test", if_not_exists="ignore", force=True)
-
     def test_with_descriptor_but_wrong_selection_key(self, selector, descriptor):
-        pxt.drop_dir("unit_test", force=True)
-
         descriptor.description_key = "wrong_key"
         with pytest.raises(
             ValueError, match="does not match selector's vectorized_key"
@@ -840,13 +747,9 @@ class TestGoldSplitter:
                 in_described_table=False,
             )
 
-        pxt.drop_dir("unit_test", if_not_exists="ignore", force=True)
-
     def test_with_descriptor_and_vectorizer_but_wrong_key(
         self, selector, descriptor, vectorizer
     ):
-        pxt.drop_dir("unit_test", force=True)
-
         descriptor.description_key = "wrong_key"
         with pytest.raises(ValueError, match="does not match vectorizer's data_key"):
             GoldSplitter(
@@ -857,11 +760,7 @@ class TestGoldSplitter:
                 in_described_table=False,
             )
 
-        pxt.drop_dir("unit_test", if_not_exists="ignore", force=True)
-
     def test_split_with_clusterizer(self, selector):
-        pxt.drop_dir("unit_test", force=True)
-
         # Build a simple vectorized table first, then let the splitter handle clustering
         sets = [GoldSet(name="train", size=0.5), GoldSet(name="val", size=0.5)]
 
@@ -921,8 +820,6 @@ class TestGoldSplitter:
         ]
         # Since we requested 2 clusters, resulting cluster ids should be a subset of {0,1}
         assert set(distinct_clusters).issubset({0, 1})
-
-        pxt.drop_dir("unit_test", if_not_exists="ignore", force=True)
 
 
 class TestCheckSetsValidity:

--- a/tests/test_vectorize.py
+++ b/tests/test_vectorize.py
@@ -383,10 +383,14 @@ class DummyDataset:
 
 
 class TestGoldVectorizer:
-    def test_vectorize_in_table_from_dataset(self):
+    def setup_method(self):
+        pxt.drop_dir("unit_test", force=True)
+        pxt.create_dir("unit_test", if_exists="ignore")
+
+    def teardown_method(self):
         pxt.drop_dir("unit_test", force=True)
 
-        pxt.create_dir("unit_test", if_exists="ignore")
+    def test_vectorize_in_table_from_dataset(self):
         table_path = "unit_test.vectorize_from_dataset"
 
         dataset = DummyDataset(dataset_len=2)
@@ -412,11 +416,7 @@ class TestGoldVectorizer:
             assert row["vectorized"].shape == (3,)
             assert row["label"] == "dummy"
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_vectorize_in_table_from_table(self):
-        pxt.drop_dir("unit_test", force=True)
-
         src_path = "unit_test.src_table_vectorize"
         desc_path = "unit_test.vectorize_from_table"
 
@@ -425,7 +425,6 @@ class TestGoldVectorizer:
             {"idx": 1, "embeddings": torch.zeros(4, 3).numpy(), "label": "dummy"},
         ]
 
-        pxt.create_dir("unit_test", if_exists="ignore")
         src_table = pxt.create_table(
             src_path, source=source_rows, if_exists="replace_force"
         )
@@ -449,11 +448,7 @@ class TestGoldVectorizer:
             assert row["vectorized"].shape == (4,)
             assert row["label"] == "dummy"
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_vectorize_in_table_with_target(self):
-        pxt.drop_dir("unit_test", force=True)
-
         src_path = "unit_test.src_table_vectorize"
         desc_path = "unit_test.vectorize_from_table"
 
@@ -472,7 +467,6 @@ class TestGoldVectorizer:
             },
         ]
 
-        pxt.create_dir("unit_test", if_exists="ignore")
         src_table = pxt.create_table(
             src_path, source=source_rows, if_exists="replace_force"
         )
@@ -496,11 +490,7 @@ class TestGoldVectorizer:
             assert row["vectorized"].shape == (4,)
             assert row["label"] == "dummy"
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_vectorize_in_table_with_multitarget(self):
-        pxt.drop_dir("unit_test", force=True)
-
         src_path = "unit_test.src_table_vectorize"
         desc_path = "unit_test.vectorize_from_table"
 
@@ -523,7 +513,6 @@ class TestGoldVectorizer:
             },
         ]
 
-        pxt.create_dir("unit_test", if_exists="ignore")
         src_table = pxt.create_table(
             src_path, source=source_rows, if_exists="replace_force"
         )
@@ -549,11 +538,7 @@ class TestGoldVectorizer:
             assert row["vectorized"].shape == (4,)
             assert row["label"] == "class_0" or row["label"] == "class_1"
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_vectorize_in_table_with_multitarget_and_merge_multilabels(self):
-        pxt.drop_dir("unit_test", force=True)
-
         src_path = "unit_test.src_table_vectorize"
         desc_path = "unit_test.vectorize_from_table"
 
@@ -576,7 +561,6 @@ class TestGoldVectorizer:
             },
         ]
 
-        pxt.create_dir("unit_test", if_exists="ignore")
         src_table = pxt.create_table(
             src_path, source=source_rows, if_exists="replace_force"
         )
@@ -603,11 +587,7 @@ class TestGoldVectorizer:
             assert row["vectorized"].shape == (4,)
             assert row["label"] == "class_0_class_1"
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_vectorize_in_table_with_multitarget_and_zero_excluded(self):
-        pxt.drop_dir("unit_test", force=True)
-
         src_path = "unit_test.src_table_vectorize"
         desc_path = "unit_test.vectorize_from_table"
 
@@ -632,7 +612,6 @@ class TestGoldVectorizer:
             },
         ]
 
-        pxt.create_dir("unit_test", if_exists="ignore")
         src_table = pxt.create_table(
             src_path, source=source_rows, if_exists="replace_force"
         )
@@ -658,11 +637,7 @@ class TestGoldVectorizer:
             assert (row["vectorized"] == torch.ones((4,))).all()
             assert row["label"] == "class_1"
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_vectorize_in_table_with_excluded_labels(self):
-        pxt.drop_dir("unit_test", force=True)
-
         src_path = "unit_test.src_table_vectorize"
         desc_path = "unit_test.vectorize_from_table"
 
@@ -687,7 +662,6 @@ class TestGoldVectorizer:
             },
         ]
 
-        pxt.create_dir("unit_test", if_exists="ignore")
         src_table = pxt.create_table(
             src_path, source=source_rows, if_exists="replace_force"
         )
@@ -713,13 +687,9 @@ class TestGoldVectorizer:
             assert (row["vectorized"] == torch.ones((4,))).all()
             assert row["label"] == "class_1"
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_vectorize_in_table_without_idx(
         self,
     ):
-        pxt.drop_dir("unit_test", force=True)
-
         def collate_fn(batch):
             data = torch.stack([b["embeddings"] for b in batch], dim=0)
             return {"embeddings": data}
@@ -748,13 +718,9 @@ class TestGoldVectorizer:
         assert idx == {0, 1}
         assert idx_vector == set(range(128))
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_vectorize_in_table_with_non_dict_item(
         self,
     ):
-        pxt.drop_dir("unit_test", force=True)
-
         gv = GoldVectorizer(
             table_path="unit_test.vectorize",
             vectorizer=TensorVectorizer(),
@@ -768,13 +734,9 @@ class TestGoldVectorizer:
         with pytest.raises(ValueError, match="Sample must be a dictionary"):
             gv.vectorize_in_table(DummyDataset())
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_vectorize_in_table_with_missing_data_key(
         self,
     ):
-        pxt.drop_dir("unit_test", force=True)
-
         gv = GoldVectorizer(
             table_path="unit_test.vectorize",
             vectorizer=TensorVectorizer(),
@@ -788,13 +750,9 @@ class TestGoldVectorizer:
         with pytest.raises(ValueError, match="Sample is missing expected keys"):
             gv.vectorize_in_table(DummyDataset())
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_vectorize_in_table_with_max_batches(
         self,
     ):
-        pxt.drop_dir("unit_test", force=True)
-
         gv = GoldVectorizer(
             table_path="unit_test.vectorize",
             vectorizer=TensorVectorizer(),
@@ -814,12 +772,7 @@ class TestGoldVectorizer:
         for i, row in enumerate(table.collect()):
             assert row["idx_vector"] == i
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_vectorize_in_dataset(self):
-        pxt.drop_dir("unit_test", force=True)
-
-        pxt.create_dir("unit_test", if_exists="ignore")
         table_path = "unit_test.vectorize_dataset"
 
         dataset = DummyDataset(dataset_len=2)
@@ -845,11 +798,7 @@ class TestGoldVectorizer:
 
         assert count == 128
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_vectorize_in_dataset_from_table(self):
-        pxt.drop_dir("unit_test", force=True)
-
         src_path = "unit_test.src_table_vectorize"
         desc_path = "unit_test.vectorize_from_table"
 
@@ -857,7 +806,6 @@ class TestGoldVectorizer:
             {"idx": 0, "embeddings": torch.zeros(3, 8, 8).numpy()},
             {"idx": 1, "embeddings": torch.zeros(3, 8, 8).numpy()},
         ]
-        pxt.create_dir("unit_test", if_exists="ignore")
         src_table = pxt.create_table(
             src_path, source=source_rows, if_exists="replace_force"
         )
@@ -883,13 +831,9 @@ class TestGoldVectorizer:
 
         assert count == 128
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_vectorize_in_table_after_restart(
         self,
     ):
-        pxt.drop_dir("unit_test", force=True)
-
         gv = GoldVectorizer(
             table_path="unit_test.vectorize",
             vectorizer=TensorVectorizer(),
@@ -916,13 +860,9 @@ class TestGoldVectorizer:
             assert row["idx_vector"] == i
             assert row["vectorized"].shape == (3,)
 
-        pxt.drop_dir("unit_test", force=True)
-
     def test_vectorize_in_table_after_restart_with_restart_disallowed(
         self,
     ):
-        pxt.drop_dir("unit_test", force=True)
-
         gv = GoldVectorizer(
             table_path="unit_test.vectorize",
             vectorizer=TensorVectorizer(),
@@ -941,8 +881,6 @@ class TestGoldVectorizer:
             ValueError, match="already exists and allow_existing is set to False"
         ):
             gv.vectorize_in_table(dataset)
-
-        pxt.drop_dir("unit_test", force=True)
 
 
 @pytest.fixture


### PR DESCRIPTION
Closes #252.

Use Pytest's standard `setup_method` and `teardown_method` inside
each test class to isolate Pixeltable state to a dedicated `unit_test`
directory.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes Pixeltable test directory cleanup using `pytest` hooks. This isolates state in the `unit_test` dir, reduces duplication, prevents cross-test leakage, and fulfills Linear #252.

- **Refactors**
  - Added `setup_method` and `teardown_method` in test classes to create/drop `unit_test` per test run.
  - Removed inline directory setup/cleanup from tests in `tests/test_describe.py`, `tests/test_select.py`, `tests/test_split.py`, and `tests/test_vectorize.py`.

<sup>Written for commit 4e9f50fa78f8cdc44f9799298dd29002c6103e7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/goldener-data/goldener/pull/258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

