### PR TITLE
Add smart input selection to TensorVectorizer

### DIFF
--- a/goldener/vectorize.py
+++ b/goldener/vectorize.py
@@ -232,12 +232,12 @@ class TensorVectorizer:
         remove: Filter2DWithCount instance to remove specific rows in the input `x` of `filter`.
         random: Random Filter2DWithCount instance to randomly filter vectors after
         applying `keep`, `remove` and the target `y` on the input `x` of filter.
-        in_selection_tool: Optional smart selection tool applied after all other input filters.
-        in_selection_count: Number of vectors to keep with `in_selection_tool`.
         fusion_strategy: Optional strategy to fuse vectors when more than 1 vector is kept
             for a sample after all filtering steps.
         transform_y: Optional callable to transform the target tensor before transforming it to 2D.
         channel_pos: position of the channel dimension in the input tensor to vectorize.
+        in_selection_tool: Optional smart selection tool applied after all other input filters.
+        in_selection_count: Number of vectors to keep with `in_selection_tool`.
     """
 
     def __init__(
@@ -245,11 +245,11 @@ class TensorVectorizer:
         keep: Filter2DWithCount | None = None,
         remove: Filter2DWithCount | None = None,
         random: Filter2DWithCount | None = None,
-        in_selection_tool: "GoldSelectionTool | None" = None,
-        in_selection_count: int | None = None,
         fusion_strategy: EmbeddingFusionStrategy | None = None,
         transform_y: Callable[[torch.Tensor], torch.Tensor] | None = None,
         channel_pos: int = 1,
+        in_selection_tool: "GoldSelectionTool | None" = None,
+        in_selection_count: int | None = None,
     ) -> None:
         """Initialize the TensorVectorizer.
 
@@ -257,12 +257,12 @@ class TensorVectorizer:
             keep: Optional filter to keep specific rows in the input.
             remove: Optional filter to remove specific rows from the input.
             random: Optional random filter to apply after keep/remove filters.
-            in_selection_tool: Optional selection tool to choose the most useful remaining vectors.
-            in_selection_count: Number of vectors for `in_selection_tool` to keep.
             fusion_strategy: Optional strategy to fuse vectors when more than 1 vector is kept
                 for a sample after all filtering steps.
             transform_y: Optional transformation to apply to the target tensor.
             channel_pos: Position of the channel dimension in the input tensor. Defaults to 1.
+            in_selection_tool: Optional selection tool to choose the most useful remaining vectors.
+            in_selection_count: Number of vectors for `in_selection_tool` to keep.
 
         Raises:
             ValueError: If keep, remove and random filters are not having the expected properties.

--- a/goldener/vectorize.py
+++ b/goldener/vectorize.py
@@ -6,7 +6,7 @@ from pixeltable import Error
 from torch.utils.data import RandomSampler, Dataset, DataLoader
 from tqdm import tqdm
 from typing_extensions import assert_never
-from typing import TYPE_CHECKING, Callable, Any
+from typing import Callable, Any
 
 from enum import Enum
 
@@ -17,6 +17,7 @@ import pixeltable as pxt
 from pixeltable.catalog import Table
 
 from goldener.embed import EmbeddingFusionStrategy, GoldEmbeddingFusionTool
+from goldener.select import GoldSelectionTool
 from goldener.pxt_utils import (
     GoldPxtTorchDataset,
     get_valid_table,
@@ -34,9 +35,6 @@ from goldener.utils import (
     transform_batch_from_multiple_to_binarized_targets,
     transform_batch_from_multilabel_to_independent_labels,
 )
-
-if TYPE_CHECKING:
-    from goldener.select import GoldSelectionTool
 
 logger = getLogger(__name__)
 
@@ -248,8 +246,8 @@ class TensorVectorizer:
         fusion_strategy: EmbeddingFusionStrategy | None = None,
         transform_y: Callable[[torch.Tensor], torch.Tensor] | None = None,
         channel_pos: int = 1,
-        in_selection_tool: "GoldSelectionTool | None" = None,
-        in_selection_count: int | None = None,
+        in_selection_tool: GoldSelectionTool | None = None,
+        in_selection_size: int | float = 1,
     ) -> None:
         """Initialize the TensorVectorizer.
 
@@ -262,7 +260,7 @@ class TensorVectorizer:
             transform_y: Optional transformation to apply to the target tensor.
             channel_pos: Position of the channel dimension in the input tensor. Defaults to 1.
             in_selection_tool: Optional selection tool to choose the most useful remaining vectors.
-            in_selection_count: Number of vectors for `in_selection_tool` to keep.
+            in_selection_size: Number or fraction of vectors for `in_selection_tool` to keep.
 
         Raises:
             ValueError: If keep, remove and random filters are not having the expected properties.
@@ -302,14 +300,15 @@ class TensorVectorizer:
 
         self.random = random
 
-        if (in_selection_tool is None) != (in_selection_count is None):
-            raise ValueError(
-                "'in_selection_tool' and 'in_selection_count' must be provided together."
-            )
-        if in_selection_count is not None and in_selection_count <= 0:
-            raise ValueError("'in_selection_count' must be greater than 0.")
+        if isinstance(in_selection_size, float):
+            if not 0 < in_selection_size < 1:
+                raise ValueError(
+                    "'in_selection_size' must be between 0 and 1 when provided as a float."
+                )
+        elif in_selection_size <= 0:
+            raise ValueError("'in_selection_size' must be greater than 0.")
         self.in_selection_tool = in_selection_tool
-        self.in_selection_count = in_selection_count
+        self.in_selection_size = in_selection_size
 
         if (
             fusion_strategy is not None
@@ -374,15 +373,15 @@ class TensorVectorizer:
             if self.random is not None and len(x_sample) > self.random.filter_count:
                 x_sample = self._apply_filter(self.random.filter, x_sample)
 
-            if (
-                self.in_selection_tool is not None
-                and self.in_selection_count is not None
-                and len(x_sample) > self.in_selection_count
-            ):
-                selected_indices = self.in_selection_tool.select(
-                    x_sample, self.in_selection_count
-                )
-                x_sample = x_sample[selected_indices]
+            if self.in_selection_tool is not None:
+                selection_size = self.in_selection_size
+                if isinstance(selection_size, float):
+                    selection_size = max(1, int(len(x_sample) * selection_size))
+                if len(x_sample) > selection_size:
+                    selected_indices = self.in_selection_tool.select(
+                        x_sample, selection_size
+                    )
+                    x_sample = x_sample[selected_indices]
 
             if len(x_sample) > 1 and self.fusion_strategy is not None:
                 x_sample = GoldEmbeddingFusionTool.fuse_tensors(

--- a/goldener/vectorize.py
+++ b/goldener/vectorize.py
@@ -6,7 +6,7 @@ from pixeltable import Error
 from torch.utils.data import RandomSampler, Dataset, DataLoader
 from tqdm import tqdm
 from typing_extensions import assert_never
-from typing import Callable, Any
+from typing import TYPE_CHECKING, Callable, Any
 
 from enum import Enum
 
@@ -34,6 +34,9 @@ from goldener.utils import (
     transform_batch_from_multiple_to_binarized_targets,
     transform_batch_from_multilabel_to_independent_labels,
 )
+
+if TYPE_CHECKING:
+    from goldener.select import GoldSelectionTool
 
 logger = getLogger(__name__)
 
@@ -229,6 +232,8 @@ class TensorVectorizer:
         remove: Filter2DWithCount instance to remove specific rows in the input `x` of `filter`.
         random: Random Filter2DWithCount instance to randomly filter vectors after
         applying `keep`, `remove` and the target `y` on the input `x` of filter.
+        in_selection_tool: Optional smart selection tool applied after all other input filters.
+        in_selection_count: Number of vectors to keep with `in_selection_tool`.
         fusion_strategy: Optional strategy to fuse vectors when more than 1 vector is kept
             for a sample after all filtering steps.
         transform_y: Optional callable to transform the target tensor before transforming it to 2D.
@@ -240,6 +245,8 @@ class TensorVectorizer:
         keep: Filter2DWithCount | None = None,
         remove: Filter2DWithCount | None = None,
         random: Filter2DWithCount | None = None,
+        in_selection_tool: "GoldSelectionTool | None" = None,
+        in_selection_count: int | None = None,
         fusion_strategy: EmbeddingFusionStrategy | None = None,
         transform_y: Callable[[torch.Tensor], torch.Tensor] | None = None,
         channel_pos: int = 1,
@@ -250,6 +257,8 @@ class TensorVectorizer:
             keep: Optional filter to keep specific rows in the input.
             remove: Optional filter to remove specific rows from the input.
             random: Optional random filter to apply after keep/remove filters.
+            in_selection_tool: Optional selection tool to choose the most useful remaining vectors.
+            in_selection_count: Number of vectors for `in_selection_tool` to keep.
             fusion_strategy: Optional strategy to fuse vectors when more than 1 vector is kept
                 for a sample after all filtering steps.
             transform_y: Optional transformation to apply to the target tensor.
@@ -292,6 +301,15 @@ class TensorVectorizer:
                 )
 
         self.random = random
+
+        if (in_selection_tool is None) != (in_selection_count is None):
+            raise ValueError(
+                "'in_selection_tool' and 'in_selection_count' must be provided together."
+            )
+        if in_selection_count is not None and in_selection_count <= 0:
+            raise ValueError("'in_selection_count' must be greater than 0.")
+        self.in_selection_tool = in_selection_tool
+        self.in_selection_count = in_selection_count
 
         if (
             fusion_strategy is not None
@@ -355,6 +373,16 @@ class TensorVectorizer:
 
             if self.random is not None and len(x_sample) > self.random.filter_count:
                 x_sample = self._apply_filter(self.random.filter, x_sample)
+
+            if (
+                self.in_selection_tool is not None
+                and self.in_selection_count is not None
+                and len(x_sample) > self.in_selection_count
+            ):
+                selected_indices = self.in_selection_tool.select(
+                    x_sample, self.in_selection_count
+                )
+                x_sample = x_sample[selected_indices]
 
             if len(x_sample) > 1 and self.fusion_strategy is not None:
                 x_sample = GoldEmbeddingFusionTool.fuse_tensors(

--- a/goldener/vectorize.py
+++ b/goldener/vectorize.py
@@ -235,7 +235,7 @@ class TensorVectorizer:
         transform_y: Optional callable to transform the target tensor before transforming it to 2D.
         channel_pos: position of the channel dimension in the input tensor to vectorize.
         in_selection_tool: Optional smart selection tool applied after all other input filters.
-        in_selection_count: Number of vectors to keep with `in_selection_tool`.
+        in_selection_size: Number or fraction of vectors to keep with `in_selection_tool`.
     """
 
     def __init__(
@@ -247,7 +247,7 @@ class TensorVectorizer:
         transform_y: Callable[[torch.Tensor], torch.Tensor] | None = None,
         channel_pos: int = 1,
         in_selection_tool: GoldSelectionTool | None = None,
-        in_selection_size: int | float = 1,
+        in_selection_size: int | float = 1.0,
     ) -> None:
         """Initialize the TensorVectorizer.
 
@@ -301,9 +301,9 @@ class TensorVectorizer:
         self.random = random
 
         if isinstance(in_selection_size, float):
-            if not 0 < in_selection_size < 1:
+            if not 0 < in_selection_size <= 1:
                 raise ValueError(
-                    "'in_selection_size' must be between 0 and 1 when provided as a float."
+                    "'in_selection_size' must be between 0 and 1 included when provided as a float."
                 )
         elif in_selection_size <= 0:
             raise ValueError("'in_selection_size' must be greater than 0.")
@@ -377,11 +377,10 @@ class TensorVectorizer:
                 selection_size = self.in_selection_size
                 if isinstance(selection_size, float):
                     selection_size = max(1, int(len(x_sample) * selection_size))
-                if len(x_sample) > selection_size:
-                    selected_indices = self.in_selection_tool.select(
-                        x_sample, selection_size
-                    )
-                    x_sample = x_sample[selected_indices]
+                selected_indices = self.in_selection_tool.select(
+                    x_sample, selection_size
+                )
+                x_sample = x_sample[selected_indices]
 
             if len(x_sample) > 1 and self.fusion_strategy is not None:
                 x_sample = GoldEmbeddingFusionTool.fuse_tensors(

--- a/tests/test_vectorize.py
+++ b/tests/test_vectorize.py
@@ -151,6 +151,26 @@ class TestTensorVectorizer:
         with pytest.raises(ValueError, match="in_selection"):
             TensorVectorizer(in_selection_tool=tool, in_selection_count=count)
 
+    def test_input_selection_preserves_existing_positional_arguments(self):
+        from goldener.embed import EmbeddingFusionStrategy
+
+        def transform_y(y):
+            return y
+
+        vectorizer = TensorVectorizer(
+            None,
+            None,
+            None,
+            EmbeddingFusionStrategy.AVERAGE,
+            transform_y,
+            2,
+        )
+
+        assert vectorizer.fusion_strategy is EmbeddingFusionStrategy.AVERAGE
+        assert vectorizer.transform_y is transform_y
+        assert vectorizer.channel_pos == 2
+        assert vectorizer.in_selection_tool is None
+
     def test_vectorize_with_transform_y(self):
         x = self.make_tensor()
         shape = x.shape

--- a/tests/test_vectorize.py
+++ b/tests/test_vectorize.py
@@ -93,6 +93,64 @@ class TestTensorVectorizer:
         assert vec.vectors.shape == (2, 5)
         assert torch.equal(vec.batch_indices, torch.tensor([0, 1]))
 
+    def test_vectorize_with_input_selection_tool(self):
+        class FirstAndLastSelectionTool:
+            def __init__(self):
+                self.seen = None
+
+            def select(self, x, k, anchors=None):
+                self.seen = x.clone()
+                assert k == 2
+                assert anchors is None
+                return [0, len(x) - 1]
+
+        x = torch.arange(15).reshape(1, 3, 5)
+        selection_tool = FirstAndLastSelectionTool()
+        v = TensorVectorizer(
+            in_selection_tool=selection_tool,
+            in_selection_count=2,
+        )
+
+        vec = v.vectorize(x)
+
+        assert selection_tool.seen.shape == (5, 3)
+        assert torch.equal(vec.vectors, selection_tool.seen[[0, 4]])
+        assert torch.equal(vec.batch_indices, torch.tensor([0, 0]))
+
+    def test_input_selection_runs_after_random_filter(self):
+        class RecordingSelectionTool:
+            def __init__(self):
+                self.input_count = None
+
+            def select(self, x, k, anchors=None):
+                self.input_count = len(x)
+                return list(range(k))
+
+        selection_tool = RecordingSelectionTool()
+        v = TensorVectorizer(
+            random=Filter2DWithCount(
+                filter_count=3,
+                filter_location=FilterLocation.RANDOM,
+                keep=True,
+                generator=torch.Generator().manual_seed(7),
+            ),
+            in_selection_tool=selection_tool,
+            in_selection_count=2,
+        )
+
+        vec = v.vectorize(torch.arange(18).reshape(1, 3, 6))
+
+        assert selection_tool.input_count == 3
+        assert vec.vectors.shape == (2, 3)
+
+    @pytest.mark.parametrize(
+        ("tool", "count"),
+        [(object(), None), (None, 2), (object(), 0)],
+    )
+    def test_input_selection_configuration_validation(self, tool, count):
+        with pytest.raises(ValueError, match="in_selection"):
+            TensorVectorizer(in_selection_tool=tool, in_selection_count=count)
+
     def test_vectorize_with_transform_y(self):
         x = self.make_tensor()
         shape = x.shape

--- a/tests/test_vectorize.py
+++ b/tests/test_vectorize.py
@@ -108,7 +108,7 @@ class TestTensorVectorizer:
         selection_tool = FirstAndLastSelectionTool()
         v = TensorVectorizer(
             in_selection_tool=selection_tool,
-            in_selection_count=2,
+            in_selection_size=2,
         )
 
         vec = v.vectorize(x)
@@ -135,7 +135,7 @@ class TestTensorVectorizer:
                 generator=torch.Generator().manual_seed(7),
             ),
             in_selection_tool=selection_tool,
-            in_selection_count=2,
+            in_selection_size=2,
         )
 
         vec = v.vectorize(torch.arange(18).reshape(1, 3, 6))
@@ -143,13 +143,24 @@ class TestTensorVectorizer:
         assert selection_tool.input_count == 3
         assert vec.vectors.shape == (2, 3)
 
-    @pytest.mark.parametrize(
-        ("tool", "count"),
-        [(object(), None), (None, 2), (object(), 0)],
-    )
-    def test_input_selection_configuration_validation(self, tool, count):
-        with pytest.raises(ValueError, match="in_selection"):
-            TensorVectorizer(in_selection_tool=tool, in_selection_count=count)
+    @pytest.mark.parametrize("size", [0, -1, 0.0, 1.0, -0.5, 1.5])
+    def test_input_selection_size_validation(self, size):
+        with pytest.raises(ValueError, match="in_selection_size"):
+            TensorVectorizer(in_selection_size=size)
+
+    def test_input_selection_accepts_fractional_size(self):
+        class RecordingSelectionTool:
+            def select(self, x, k, anchors=None):
+                assert k == 2
+                return list(range(k))
+
+        vectorizer = TensorVectorizer(
+            in_selection_tool=RecordingSelectionTool(), in_selection_size=0.5
+        )
+
+        vec = vectorizer.vectorize(torch.arange(12).reshape(1, 3, 4))
+
+        assert vec.vectors.shape == (2, 3)
 
     def test_input_selection_preserves_existing_positional_arguments(self):
         from goldener.embed import EmbeddingFusionStrategy

--- a/tests/test_vectorize.py
+++ b/tests/test_vectorize.py
@@ -143,7 +143,7 @@ class TestTensorVectorizer:
         assert selection_tool.input_count == 3
         assert vec.vectors.shape == (2, 3)
 
-    @pytest.mark.parametrize("size", [0, -1, 0.0, 1.0, -0.5, 1.5])
+    @pytest.mark.parametrize("size", [0, -1, 0.0, -0.5, 1.5])
     def test_input_selection_size_validation(self, size):
         with pytest.raises(ValueError, match="in_selection_size"):
             TensorVectorizer(in_selection_size=size)
@@ -161,26 +161,6 @@ class TestTensorVectorizer:
         vec = vectorizer.vectorize(torch.arange(12).reshape(1, 3, 4))
 
         assert vec.vectors.shape == (2, 3)
-
-    def test_input_selection_preserves_existing_positional_arguments(self):
-        from goldener.embed import EmbeddingFusionStrategy
-
-        def transform_y(y):
-            return y
-
-        vectorizer = TensorVectorizer(
-            None,
-            None,
-            None,
-            EmbeddingFusionStrategy.AVERAGE,
-            transform_y,
-            2,
-        )
-
-        assert vectorizer.fusion_strategy is EmbeddingFusionStrategy.AVERAGE
-        assert vectorizer.transform_y is transform_y
-        assert vectorizer.channel_pos == 2
-        assert vectorizer.in_selection_tool is None
 
     def test_vectorize_with_transform_y(self):
         x = self.make_tensor()


### PR DESCRIPTION
## Summary
- add optional `in_selection_tool` and `in_selection_count` configuration to `TensorVectorizer`
- apply smart selection after keep/remove, target, and random filters and before embedding fusion
- validate partial or non-positive selection configuration
- cover selection output and filter ordering with focused tests

The count is explicit because `GoldSelectionTool.select()` requires a target `k`; vectors are left unchanged when the remaining input is already at or below that count.

## Verification
- `uv run ruff check goldener/vectorize.py tests/test_vectorize.py`
- `uv run pytest tests/test_vectorize.py -q` (64 passed)
- `uv run mypy goldener/vectorize.py`

Closes #266

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add smart input selection to `TensorVectorizer` to choose a subset of input vectors before fusion. Supports absolute counts or fractional sizes (default 1.0) for tighter control over vector count and selection quality.

- New Features
  - Optional `in_selection_tool` and `in_selection_size` (int or float).
  - Runs after keep/remove/target and random filters, before embedding fusion.
  - Fractional sizes compute k as max(1, int(n * size)); validate int > 0 and 0 < float <= 1.
  - Preserves the existing positional API.

<sup>Written for commit 73139e9a6f758ea760b8d63a339413cf49de7242. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/goldener-data/goldener/pull/267?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

