### PR TITLE
selection_key added in split, select and clusterize

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,8 @@ x_reduced = reducer.fit_transform(x)  # shape: (50, 2)
 
 ## Balancing batches during training
 
-When training with randomly sampled batches, the content distribution within each batch can vary a lot — 
-some batches may end up overrepresenting certain types of data while barely including others. This imbalance 
+When training with randomly sampled batches, the content distribution within each batch can vary a lot —
+some batches may end up overrepresenting certain types of data while barely including others. This imbalance
 can hurt how well a model learns to recognize the underrepresented cases.
 
 Goldener proposes a batch sampler grouping data into groups of similar content, and then drawing samples so each batch is spread across clusters as evenly as possible.

--- a/goldener/clusterize.py
+++ b/goldener/clusterize.py
@@ -768,7 +768,7 @@ class GoldClusterizer:
     @staticmethod
     def get_cluster_indices(
         table: Table,
-        cluster_key: str= "cluster",
+        cluster_key: str = "cluster",
         cluster_idx: int | None = None,
         label_key: str | None = None,
         label_value: str | None = None,

--- a/goldener/clusterize.py
+++ b/goldener/clusterize.py
@@ -768,7 +768,7 @@ class GoldClusterizer:
     @staticmethod
     def get_cluster_indices(
         table: Table,
-        cluster_key: str,
+        cluster_key: str= "cluster",
         cluster_idx: int | None = None,
         label_key: str | None = None,
         label_value: str | None = None,

--- a/goldener/select.py
+++ b/goldener/select.py
@@ -1342,7 +1342,7 @@ class GoldSelector:
     def get_selection_indices(
         table: Table,
         value: str | None,
-        selection_key: str,
+        selection_key: str = "selected",
         label_key: str | None = None,
         label_value: str | None = None,
         idx_key: str = "idx",

--- a/goldener/split.py
+++ b/goldener/split.py
@@ -282,7 +282,7 @@ class GoldSplitter:
     @staticmethod
     def get_split_indices(
         split_data: Table | Dataset,
-        selection_key: str,
+        selection_key: str = "selected",
         idx_key: str = "idx",
         batch_size: int = 1024,
         num_workers: int = 0,


### PR DESCRIPTION
## Summary

This pull request adds a default value of `"selected"` for the `selection_key` parameter in the split, select, and clusterize components.

## Changes

- Set `selection_key: str = "selected"` in:
  - `GoldSplitter`
  - `GoldSelector`
  - `GoldClusterize`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set default keys for selection and clustering to reduce boilerplate. `selection_key` now defaults to "selected" in split/select, and `cluster_key` to "cluster" in clusterize; minor README cleanup and code formatted with `ruff`.

<sup>Written for commit 27c6e9957a5a367e64102672f4740617e9de917c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/goldener-data/goldener/pull/279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

