### PR TITLE
Rename TensorVectorizer to GoldTensorVectorizationTool

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ from goldener import (
     GoldDescriptor,
     GoldTorchEmbeddingTool,
     GoldTorchEmbeddingToolConfig,
-    TensorVectorizer,
+    GoldTensorVectorizationTool,
 )
 
 gd = GoldDescriptor(
@@ -81,7 +81,7 @@ gd = GoldDescriptor(
             layers=my_layers,
         )
     ),
-    vectorizer=TensorVectorizer()
+    vectorizer=GoldTensorVectorizationTool()
 )
 
 gs = GoldSelector(
@@ -138,7 +138,7 @@ from goldener import (
     GoldDescriptor,
     GoldTorchEmbeddingTool,
     GoldTorchEmbeddingToolConfig,
-    TensorVectorizer,
+    GoldTensorVectorizationTool,
 )
 from sklearn.cluster import KMeans
 

--- a/docs/posts/GOLD_BATCHER.md
+++ b/docs/posts/GOLD_BATCHER.md
@@ -21,7 +21,7 @@ embedder_config = GoldTorchEmbeddingToolConfig(
     channel_pos=1,
 )
 embedder = GoldTorchEmbeddingTool(embedder_config)
-vectorizer = TensorVectorizer(
+vectorizer = GoldTensorVectorizationTool(
     keep=Filter2DWithCount(
         filter_count=1,
         filter_location=FilterLocation.START,
@@ -105,7 +105,7 @@ embedder_config = GoldTorchEmbeddingToolConfig(
     channel_pos=1,
 )
 embedder = GoldTorchEmbeddingTool(embedder_config)
-vectorizer = TensorVectorizer(
+vectorizer = GoldTensorVectorizationTool(
     keep=Filter2DWithCount(
         filter_count=1,
         filter_location=FilterLocation.START,

--- a/docs/posts/GOLD_SELECTION.md
+++ b/docs/posts/GOLD_SELECTION.md
@@ -21,7 +21,7 @@ embedder_config = GoldTorchEmbeddingToolConfig(
     channel_pos=1,
 )
 embedder = GoldTorchEmbeddingTool(embedder_config)
-vectorizer = TensorVectorizer(
+vectorizer = GoldTensorVectorizationTool(
     keep=Filter2DWithCount(
         filter_count=1,
         filter_location=FilterLocation.START,
@@ -92,7 +92,7 @@ embedder_config = GoldTorchEmbeddingToolConfig(
     channel_pos=1,
 )
 embedder = GoldTorchEmbeddingTool(embedder_config)
-vectorizer = TensorVectorizer(
+vectorizer = GoldTensorVectorizationTool(
     keep=Filter2DWithCount(
         filter_count=1,
         filter_location=FilterLocation.START,

--- a/docs/posts/GOLD_SPLIT.md
+++ b/docs/posts/GOLD_SPLIT.md
@@ -21,7 +21,7 @@ embedder_config = GoldTorchEmbeddingToolConfig(
     channel_pos=1,
 )
 embedder = GoldTorchEmbeddingTool(embedder_config)
-vectorizer = TensorVectorizer(
+vectorizer = GoldTensorVectorizationTool(
     keep=Filter2DWithCount(
         filter_count=1,
         filter_location=FilterLocation.START,
@@ -137,11 +137,11 @@ The main entry point in the code is [GoldVectorizer](https://github.com/goldener
 Depending on the input data and the model, the `Description` of each sample might be a multidimensions tensor instead of a single vector (a feature map from an image, temporal evolution description from a signal, among others). In [Goldener](https://github.com/goldener-data/goldener), the selection tools are designed to process vectors, this makes them input type/task agnostic. Thus, Goldener proposes a `GoldVectorizer` in order to move from a batch of tensors to a list of vectors.
 
 The [Goldener](https://github.com/goldener-data/goldener) orchestrating the vectorization of a full dataset is `GoldVectorizer`.
-Its main building block is the `TensorVectorizer` which vectorizes its input regardless of the tensor shape. Within the input tensor, some vectors can be selected or ignored from the `keep`, `remove`, `random` attributes. Furthermore, when more than one vector is still present in the description of a sample, the remaining vectors can be aggregated together (same possibilities as for the layers). Finally, depending on the task and dataset, some local annotations might be available. Then, the vectorizer can use this information to restrict the focus of the description on the specific annotated elements. If the annotation is required to be adapted to the description scale, the user can specify a specific transform in order to adapt the annotation.
+Its main building block is the `GoldTensorVectorizationTool` which vectorizes its input regardless of the tensor shape. Within the input tensor, some vectors can be selected or ignored from the `keep`, `remove`, `random` attributes. Furthermore, when more than one vector is still present in the description of a sample, the remaining vectors can be aggregated together (same possibilities as for the layers). Finally, depending on the task and dataset, some local annotations might be available. Then, the vectorizer can use this information to restrict the focus of the description on the specific annotated elements. If the annotation is required to be adapted to the description scale, the user can specify a specific transform in order to adapt the annotation.
 
 In [Goldener](https://github.com/goldener-data/goldener), `GoldVectorizer` is callable from either a PyTorch `Dataset` or Pixeltable `Table`. If a `Dataset` is provided, each sample is expected to be accessible as a dictionary containing the keys defined in `data_key`, `target_key`, and `label_key` attributes (if it is not initially in this format, a custom collate function must be provided). The input data is processed sequentially batch by batch using a PyTorch `DataLoader`. At the end of its task, the `GoldVectorizer` returns a PyTorch `Dataset` via `vectorize_in_dataset` or a Pixeltable `Table` via `vectorize_in_table`. At the end, the vectors are stored within the column defined by the `vectorized_key` attribute. The output also includes the `idx` and `idx_vector` fields, with `idx` storing the index of the sample and `idx_vector` the index of the vector (a sample might be described by multiple vectors).
 
-When the `Description` is not yet available and the processing pipeline requires the data to be vectorized, it is advised to instantiate the `TensorVectorizer` in the `GoldDescriptor` object of [Goldener](https://github.com/goldener-data/goldener). It avoids making new iterations with data loading and storage actions, and finally makes the whole operation faster.
+When the `Description` is not yet available and the processing pipeline requires the data to be vectorized, it is advised to instantiate the `GoldTensorVectorizationTool` in the `GoldDescriptor` object of [Goldener](https://github.com/goldener-data/goldener). It avoids making new iterations with data loading and storage actions, and finally makes the whole operation faster.
 
 ```python
 # Create a vectorizer to split the samples as vectors
@@ -151,7 +151,7 @@ keep = Filter2DWithCount(
     filter_location=FilterLocation.START,
     keep=True,
 )
-vectorizer = TensorVectorizer(
+vectorizer = GoldTensorVectorizationTool(
     keep=keep,
     fusion_strategy=EmbeddingFusionStrategy.AVERAGE,
     transform_y=None,

--- a/goldener/__init__.py
+++ b/goldener/__init__.py
@@ -36,7 +36,7 @@ from goldener.vectorize import (
     Filter2DWithCount,
     FilterLocation,
     Vectorized,
-    TensorVectorizer,
+    GoldTensorVectorizationTool,
 )
 
 
@@ -69,5 +69,5 @@ __all__ = (
     "Filter2DWithCount",
     "FilterLocation",
     "Vectorized",
-    "TensorVectorizer",
+    "GoldTensorVectorizationTool",
 )

--- a/goldener/describe.py
+++ b/goldener/describe.py
@@ -22,7 +22,10 @@ from goldener.pxt_utils import (
 )
 from goldener.torch_utils import get_dataset_sample_dict
 from goldener.utils import filter_batch_from_indices
-from goldener.vectorize import TensorVectorizer, vectorize_and_unwrap_in_batch
+from goldener.vectorize import (
+    GoldTensorVectorizationTool,
+    vectorize_and_unwrap_in_batch,
+)
 
 logger = getLogger(__name__)
 
@@ -47,7 +50,7 @@ class GoldDescriptor:
     Attributes:
         table_path: Path to the PixelTable table where descriptions will be saved locally.
         embedder: GoldEmbeddingTool instance for embedding the data.
-        vectorizer: Optional TensorVectorizer to further vectorize the computed embeddings
+        vectorizer: Optional GoldTensorVectorizationTool to further vectorize the computed embeddings
             before storing them in the table.
         transform: Optional transformation to apply to the data before embedding computation if not already
             applied by the `collate_fn`.
@@ -89,7 +92,7 @@ class GoldDescriptor:
         self,
         table_path: str,
         embedder: GoldEmbeddingTool,
-        vectorizer: TensorVectorizer | None = None,
+        vectorizer: GoldTensorVectorizationTool | None = None,
         transform: Callable | None = None,
         collate_fn: Callable | None = None,
         data_key: str = "data",
@@ -116,7 +119,7 @@ class GoldDescriptor:
         Args:
             table_path: Path to the PixelTable table where descriptions will be saved.
             embedder: GoldEmbeddingTool instance for embedding data.
-            vectorizer: Optional TensorVectorizer to further vectorize the computed embeddings.
+            vectorizer: Optional GoldTensorVectorizationTool to further vectorize the computed embeddings.
             transform: Optional transformation to apply before embedding computation.
             collate_fn: Optional function to collate dataset samples into batches.
                 If None, `pxt_torch_dataset_collate_fn` is used.

--- a/goldener/vectorize.py
+++ b/goldener/vectorize.py
@@ -222,7 +222,7 @@ class Vectorized:
     batch_indices: torch.Tensor
 
 
-class TensorVectorizer:
+class GoldTensorVectorizationTool:
     """Transform input as 2D tensor and filter based on target tensor.
 
     Attributes:
@@ -249,7 +249,7 @@ class TensorVectorizer:
         in_selection_tool: GoldSelectionTool | None = None,
         in_selection_size: int | float = 1.0,
     ) -> None:
-        """Initialize the TensorVectorizer.
+        """Initialize the GoldTensorVectorizationTool.
 
         Args:
             keep: Optional filter to keep specific rows in the input.
@@ -315,7 +315,7 @@ class TensorVectorizer:
             and fusion_strategy is EmbeddingFusionStrategy.CONCAT
         ):
             raise ValueError(
-                "The CONCAT fusion strategy is not supported in TensorVectorizer because "
+                "The CONCAT fusion strategy is not supported in GoldTensorVectorizationTool because "
                 "it does not preserve the original vector size"
             )
         self.fusion_strategy = fusion_strategy
@@ -456,7 +456,7 @@ class GoldVectorizer:
     """Extract and flatten vectors from dataset samples and store results in a PixelTable table.
 
     The GoldVectorizer processes a dataset or PixelTable table to extract and flatten vectors using a
-    `TensorVectorizer`. The computed vectors are stored in a local PixelTable table
+    `GoldTensorVectorizationTool`. The computed vectors are stored in a local PixelTable table
     (specified by `table_path`) so that the vectorization process is idempotent: calling the
     same operation multiple times will not duplicate or recompute vectors that are already
     present in the table.
@@ -471,7 +471,7 @@ class GoldVectorizer:
 
     Attributes:
         table_path: Path to the PixelTable table where vectorized outputs will be stored locally.
-        vectorizer: TensorVectorizer instance for transforming batched inputs into vectors.
+        vectorizer: GoldTensorVectorizationTool instance for transforming batched inputs into vectors.
         collate_fn: Optional function to collate dataset samples into batches composed of
             dictionaries with at least the key specified by `data_key` returning a PyTorch Tensor.
             If None, `pxt_torch_dataset_collate_fn` is used, which preserves list-valued
@@ -505,7 +505,7 @@ class GoldVectorizer:
     def __init__(
         self,
         table_path: str,
-        vectorizer: TensorVectorizer,
+        vectorizer: GoldTensorVectorizationTool,
         collate_fn: Callable | None = None,
         data_key: str = "embeddings",
         target_key: str = "target",
@@ -528,7 +528,7 @@ class GoldVectorizer:
 
         Args:
             table_path: Path to the PixelTable table for storing vectors.
-            vectorizer: TensorVectorizer instance for transforming tensors.
+            vectorizer: GoldTensorVectorizationTool instance for transforming tensors.
             collate_fn: Optional collate function for preparing batches.
                 If None, `pxt_torch_dataset_collate_fn` is used.
             data_key: Key for data in the batch dictionary. Defaults to "embeddings".
@@ -578,7 +578,7 @@ class GoldVectorizer:
         """Extract and flatten vectors from samples and return results as a GoldPxtTorchDataset.
 
         The vectorization process extracts and flattens vectors from the provided dataset or table
-        using the `TensorVectorizer` instance and stores them in a PixelTable table specified by `table_path`.
+        using the `GoldTensorVectorizationTool` instance and stores them in a PixelTable table specified by `table_path`.
         The resulting vectors are stored in the column specified by `vectorized_key`.
 
         This is a convenience wrapper that runs `vectorize_in_table` to populate
@@ -612,7 +612,7 @@ class GoldVectorizer:
         """Extract and flatten vectors from samples and store results in a PixelTable table.
 
         The vectorization process extracts and flattens vectors from the provided dataset or table
-        using the `TensorVectorizer` instance and stores them in a PixelTable table specified by `table_path`.
+        using the `GoldTensorVectorizationTool` instance and stores them in a PixelTable table specified by `table_path`.
         The resulting vectors are stored in the column specified by `vectorized_key`.
 
         This method is idempotent (i.e., failure proof), meaning that if it is called
@@ -830,7 +830,7 @@ class GoldVectorizer:
         """Run sequential (single-process) vectorization process.
 
         This private method processes the dataset in batches, applies vectorization using
-        the TensorVectorizer, and stores the results in the vectorized table. It is idempotent
+        the GoldTensorVectorizationTool, and stores the results in the vectorized table. It is idempotent
         and will skip samples that have already been vectorized.
 
         Args:
@@ -1033,7 +1033,7 @@ def unwrap_vectors_in_batch(
 
 def vectorize_and_unwrap_in_batch(
     batch: dict[str, Any],
-    vectorizer: TensorVectorizer,
+    vectorizer: GoldTensorVectorizationTool,
     data_key: str,
     vectorized_key: str,
     target_key: str | None = None,
@@ -1048,11 +1048,11 @@ def vectorize_and_unwrap_in_batch(
     """Vectorize a batch and insert the results into a PixelTable table.
 
     This function vectorizes the data in the provided batch using the specified
-    TensorVectorizer and inserts the resulting vectors into the given PixelTable table.
+    GoldTensorVectorizationTool and inserts the resulting vectors into the given PixelTable table.
 
     Args:
         batch: The batch dictionary containing data to vectorize.
-        vectorizer: The TensorVectorizer instance to use for vectorization.
+        vectorizer: The GoldTensorVectorizationTool instance to use for vectorization.
         data_key: Key in the batch dictionary that contains the data to vectorize.
         vectorized_key: Column name to store the resulting vectors in the PixelTable table.
         target_key: Optional key in the batch dictionary containing the target used to filter vectors.

--- a/goldener/vision/vectorizers.py
+++ b/goldener/vision/vectorizers.py
@@ -2,12 +2,16 @@ from typing import Callable
 
 import torch
 
-from goldener.vectorize import TensorVectorizer, Filter2DWithCount, FilterLocation
+from goldener.vectorize import (
+    GoldTensorVectorizationTool,
+    Filter2DWithCount,
+    FilterLocation,
+)
 
 
-def get_vit_class_token_vectorizer() -> TensorVectorizer:
-    """Get a TensorVectorizer that keeps only the class token from a ViT model."""
-    return TensorVectorizer(
+def get_vit_class_token_vectorizer() -> GoldTensorVectorizationTool:
+    """Get a GoldTensorVectorizationTool that keeps only the class token from a ViT model."""
+    return GoldTensorVectorizationTool(
         keep=Filter2DWithCount(
             filter_count=1, keep=True, filter_location=FilterLocation.START
         ),
@@ -15,8 +19,10 @@ def get_vit_class_token_vectorizer() -> TensorVectorizer:
     )
 
 
-def get_vit_prefix_tokens_vectorizer(n_prefixes: int = 5) -> TensorVectorizer:
-    """Get a TensorVectorizer that keeps the first n_prefixes tokens from a ViT model.
+def get_vit_prefix_tokens_vectorizer(
+    n_prefixes: int = 5,
+) -> GoldTensorVectorizationTool:
+    """Get a GoldTensorVectorizationTool that keeps the first n_prefixes tokens from a ViT model.
 
     Args:
         n_prefixes: The number of prefix tokens to keep (default is 5).
@@ -24,7 +30,7 @@ def get_vit_prefix_tokens_vectorizer(n_prefixes: int = 5) -> TensorVectorizer:
     if n_prefixes <= 0:
         raise ValueError("n_prefixes must be a positive integer")
 
-    return TensorVectorizer(
+    return GoldTensorVectorizationTool(
         keep=Filter2DWithCount(
             filter_count=n_prefixes, keep=True, filter_location=FilterLocation.START
         ),
@@ -37,8 +43,8 @@ def get_vit_patch_tokens_vectorizer(
     n_random: int | None = None,
     transform_y: Callable[[torch.Tensor], torch.Tensor] | None = None,
     generator: torch.Generator | None = None,
-) -> TensorVectorizer:
-    """Get a TensorVectorizer that keeps the patch tokens from a ViT model
+) -> GoldTensorVectorizationTool:
+    """Get a GoldTensorVectorizationTool that keeps the patch tokens from a ViT model
 
     It optionally removes the first n_prefixes tokens and keeps n_random random tokens.
 
@@ -56,7 +62,7 @@ def get_vit_patch_tokens_vectorizer(
     if n_random is not None and n_random <= 0:
         raise ValueError("n_random must be a positive integer or None")
 
-    return TensorVectorizer(
+    return GoldTensorVectorizationTool(
         remove=(
             Filter2DWithCount(
                 filter_count=n_prefixes,

--- a/tests/test_describe.py
+++ b/tests/test_describe.py
@@ -9,7 +9,7 @@ import pixeltable as pxt
 from goldener.describe import GoldDescriptor
 from goldener.embed import GoldTorchEmbeddingToolConfig, GoldTorchEmbeddingTool
 from goldener.pxt_utils import pxt_torch_dataset_collate_fn
-from goldener.vectorize import TensorVectorizer
+from goldener.vectorize import GoldTensorVectorizationTool
 
 
 class DummyModel(torch.nn.Module):
@@ -33,7 +33,7 @@ def embedder():
 
 @pytest.fixture
 def vectorizer():
-    return TensorVectorizer()
+    return GoldTensorVectorizationTool()
 
 
 class DummyDataset:
@@ -785,7 +785,7 @@ class TestGoldDescriptor:
         desc = GoldDescriptor(
             table_path="unit_test.test_describe",
             embedder=embedder,
-            vectorizer=TensorVectorizer(),
+            vectorizer=GoldTensorVectorizationTool(),
             batch_size=2,
             collate_fn=None,
             device=torch.device("cpu"),

--- a/tests/test_organize.py
+++ b/tests/test_organize.py
@@ -16,7 +16,7 @@ from goldener.organize import (
     get_indices_per_cluster_for_subset,
 )
 from goldener.pxt_utils import pxt_torch_dataset_collate_fn
-from goldener.vectorize import GoldVectorizer, TensorVectorizer
+from goldener.vectorize import GoldVectorizer, GoldTensorVectorizationTool
 
 
 class DummyDataset(Dataset):
@@ -53,7 +53,7 @@ def descriptor():
 def vectorizer():
     return GoldVectorizer(
         table_path="unit_test.vectorizer_batcher",
-        vectorizer=TensorVectorizer(),
+        vectorizer=GoldTensorVectorizationTool(),
         collate_fn=pxt_torch_dataset_collate_fn,
         batch_size=2,
     )

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -10,7 +10,7 @@ from goldener.describe import GoldDescriptor
 from goldener.embed import GoldTorchEmbeddingToolConfig, GoldTorchEmbeddingTool
 from goldener.pxt_utils import pxt_torch_dataset_collate_fn
 from goldener.split import GoldSplitter, GoldSet, check_sets_validity
-from goldener.vectorize import TensorVectorizer, GoldVectorizer
+from goldener.vectorize import GoldTensorVectorizationTool, GoldVectorizer
 from goldener.select import GoldSelector
 
 
@@ -71,7 +71,7 @@ def selector():
 def vectorizer():
     return GoldVectorizer(
         table_path="unit_test.vectorizer_split",
-        vectorizer=TensorVectorizer(),
+        vectorizer=GoldTensorVectorizationTool(),
         to_keep_schema={"label": pxt.String},
         collate_fn=pxt_torch_dataset_collate_fn,
         batch_size=2,
@@ -603,7 +603,7 @@ class TestGoldSplitter:
         descriptor = GoldDescriptor(
             table_path="unit_test.descriptor_split",
             embedder=embedder,
-            vectorizer=TensorVectorizer(),
+            vectorizer=GoldTensorVectorizationTool(),
             description_key="vectorized",
             batch_size=2,
             collate_fn=None,

--- a/tests/test_vectorize.py
+++ b/tests/test_vectorize.py
@@ -5,7 +5,7 @@ import pytest
 import pixeltable as pxt
 from goldener.pxt_utils import pxt_torch_dataset_collate_fn
 from goldener.vectorize import (
-    TensorVectorizer,
+    GoldTensorVectorizationTool,
     Filter2DWithCount,
     FilterLocation,
     GoldVectorizer,
@@ -15,20 +15,20 @@ from goldener.vectorize import (
 )
 
 
-class TestTensorVectorizer:
+class TestGoldTensorVectorizationTool:
     def make_tensor(self, shape=(2, 5, 2)):
         return torch.randint(0, 100, shape)
 
     def test_vectorize_no_y(self):
         x = self.make_tensor()
-        v = TensorVectorizer()
+        v = GoldTensorVectorizationTool()
         vec = v.vectorize(x)
         assert vec.vectors.shape == (4, 5)
         assert torch.equal(vec.batch_indices, torch.tensor([0, 0, 1, 1]))
 
     def test_vectorize_with_different_channel_pos(self):
         x = self.make_tensor((2, 2, 5))
-        v = TensorVectorizer(channel_pos=2)
+        v = GoldTensorVectorizationTool(channel_pos=2)
         vec = v.vectorize(x)
         assert vec.vectors.shape == (4, 5)
         assert torch.equal(vec.batch_indices, torch.tensor([0, 0, 1, 1]))
@@ -37,7 +37,7 @@ class TestTensorVectorizer:
         x = self.make_tensor()
         y = torch.ones(2, 1, 2)
         y[0, 0, 0] = 0
-        v = TensorVectorizer()
+        v = GoldTensorVectorizationTool()
         vec = v.vectorize(x, y)
         assert vec.vectors.shape == (3, 5)
         assert torch.equal(vec.batch_indices, torch.tensor([0, 1, 1]))
@@ -45,7 +45,7 @@ class TestTensorVectorizer:
     def test_vectorize_with_y_and_full_zero(self):
         x = self.make_tensor((2, 2, 5))
         y = torch.zeros(2, 2)
-        v = TensorVectorizer(channel_pos=2)
+        v = GoldTensorVectorizationTool(channel_pos=2)
         vec = v.vectorize(x, y)
         assert vec.vectors.shape == (4, 5)
 
@@ -54,7 +54,7 @@ class TestTensorVectorizer:
         keep = Filter2DWithCount(
             filter_count=1, filter_location=FilterLocation.START, keep=True
         )
-        v = TensorVectorizer(keep=keep)
+        v = GoldTensorVectorizationTool(keep=keep)
         vec = v.vectorize(x)
         assert vec.vectors.shape == (2, 5)
         assert torch.equal(vec.batch_indices, torch.tensor([0, 1]))
@@ -64,7 +64,7 @@ class TestTensorVectorizer:
         remove = Filter2DWithCount(
             filter_count=1, filter_location=FilterLocation.END, keep=False
         )
-        v = TensorVectorizer(remove=remove)
+        v = GoldTensorVectorizationTool(remove=remove)
         vec = v.vectorize(x)
         assert vec.vectors.shape == (2, 5)
         assert torch.equal(vec.batch_indices, torch.tensor([0, 1]))
@@ -77,14 +77,14 @@ class TestTensorVectorizer:
         remove = Filter2DWithCount(
             filter_count=1, filter_location=FilterLocation.END, keep=False
         )
-        v = TensorVectorizer(keep=keep, remove=remove)
+        v = GoldTensorVectorizationTool(keep=keep, remove=remove)
         vec = v.vectorize(x)
         assert vec.vectors.shape == (2, 5)
         assert torch.equal(vec.batch_indices, torch.tensor([0, 1]))
 
     def test_vectorize_with_random(self):
         x = self.make_tensor()
-        v = TensorVectorizer(
+        v = GoldTensorVectorizationTool(
             random=Filter2DWithCount(
                 filter_count=1, filter_location=FilterLocation.RANDOM, keep=True
             )
@@ -106,7 +106,7 @@ class TestTensorVectorizer:
 
         x = torch.arange(15).reshape(1, 3, 5)
         selection_tool = FirstAndLastSelectionTool()
-        v = TensorVectorizer(
+        v = GoldTensorVectorizationTool(
             in_selection_tool=selection_tool,
             in_selection_size=2,
         )
@@ -127,7 +127,7 @@ class TestTensorVectorizer:
                 return list(range(k))
 
         selection_tool = RecordingSelectionTool()
-        v = TensorVectorizer(
+        v = GoldTensorVectorizationTool(
             random=Filter2DWithCount(
                 filter_count=3,
                 filter_location=FilterLocation.RANDOM,
@@ -146,7 +146,7 @@ class TestTensorVectorizer:
     @pytest.mark.parametrize("size", [0, -1, 0.0, -0.5, 1.5])
     def test_input_selection_size_validation(self, size):
         with pytest.raises(ValueError, match="in_selection_size"):
-            TensorVectorizer(in_selection_size=size)
+            GoldTensorVectorizationTool(in_selection_size=size)
 
     def test_input_selection_accepts_fractional_size(self):
         class RecordingSelectionTool:
@@ -154,7 +154,7 @@ class TestTensorVectorizer:
                 assert k == 2
                 return list(range(k))
 
-        vectorizer = TensorVectorizer(
+        vectorizer = GoldTensorVectorizationTool(
             in_selection_tool=RecordingSelectionTool(), in_selection_size=0.5
         )
 
@@ -173,7 +173,7 @@ class TestTensorVectorizer:
             # Only keep rows where y > 5
             return (y > 5).to(torch.int64)
 
-        v = TensorVectorizer(transform_y=transform_y)
+        v = GoldTensorVectorizationTool(transform_y=transform_y)
         vec = v.vectorize(x, y)
         assert vec.vectors.shape == (2, 5)
         assert torch.equal(vec.batch_indices, torch.tensor([0, 1]))
@@ -181,13 +181,13 @@ class TestTensorVectorizer:
     def test_vectorize_shape_mismatch(self):
         x = self.make_tensor()
         y = torch.ones(2, 1, 3)
-        v = TensorVectorizer()
+        v = GoldTensorVectorizationTool()
         with pytest.raises(ValueError):
             v.vectorize(x, y)
 
     def test_vectorize_2d_input(self):
         x = self.make_tensor((4, 5))
-        v = TensorVectorizer()
+        v = GoldTensorVectorizationTool()
         with pytest.raises(ValueError):
             v.vectorize(x)
 
@@ -199,7 +199,7 @@ class TestTensorVectorizer:
             keep=True,
         )
         with pytest.raises(ValueError, match="keep"):
-            TensorVectorizer(keep=keep)
+            GoldTensorVectorizationTool(keep=keep)
 
     def test_vectorizer_invalid_keep_type_not_keeping(self):
         # keep filter must have keep=True
@@ -209,7 +209,7 @@ class TestTensorVectorizer:
             keep=False,
         )
         with pytest.raises(ValueError, match="keep"):
-            TensorVectorizer(keep=keep)
+            GoldTensorVectorizationTool(keep=keep)
 
     def test_vectorizer_invalid_remove_type_random(self):
         # remove filter cannot be random
@@ -219,7 +219,7 @@ class TestTensorVectorizer:
             keep=False,
         )
         with pytest.raises(ValueError, match="remove"):
-            TensorVectorizer(remove=remove)
+            GoldTensorVectorizationTool(remove=remove)
 
     def test_vectorizer_invalid_remove_type_not_removing(self):
         # remove filter must have keep=False
@@ -229,7 +229,7 @@ class TestTensorVectorizer:
             keep=True,
         )
         with pytest.raises(ValueError, match="remove"):
-            TensorVectorizer(remove=remove)
+            GoldTensorVectorizationTool(remove=remove)
 
     def test_vectorizer_invalid_random_type_not_random(self):
         # random filter must be random
@@ -239,7 +239,7 @@ class TestTensorVectorizer:
             keep=True,
         )
         with pytest.raises(ValueError, match="random"):
-            TensorVectorizer(random=rand)
+            GoldTensorVectorizationTool(random=rand)
 
     def test_vectorizer_invalid_random_type_not_keeping(self):
         # random filter must have keep=True so it selects indices to keep
@@ -249,7 +249,7 @@ class TestTensorVectorizer:
             keep=False,
         )
         with pytest.raises(ValueError, match="random"):
-            TensorVectorizer(random=rand)
+            GoldTensorVectorizationTool(random=rand)
 
     def test_vectorizer_valid_filters_combination(self):
         # Sanity check: valid combination should construct without errors
@@ -268,7 +268,7 @@ class TestTensorVectorizer:
             filter_location=FilterLocation.RANDOM,
             keep=True,
         )
-        v = TensorVectorizer(keep=keep, remove=remove, random=rand)
+        v = GoldTensorVectorizationTool(keep=keep, remove=remove, random=rand)
         x = self.make_tensor()
         _ = v.vectorize(x)
 
@@ -288,7 +288,7 @@ class TestTensorVectorizer:
 
         from goldener.embed import EmbeddingFusionStrategy
 
-        v = TensorVectorizer(fusion_strategy=EmbeddingFusionStrategy.AVERAGE)
+        v = GoldTensorVectorizationTool(fusion_strategy=EmbeddingFusionStrategy.AVERAGE)
         vec = v.vectorize(x)
 
         assert vec.vectors.shape[0] == 2
@@ -465,7 +465,7 @@ class TestGoldVectorizer:
     def test_collate_fn_defaults_to_pxt_torch_dataset_collate_fn(self):
         gv = GoldVectorizer(
             table_path="unit_test.vectorize_default_collate",
-            vectorizer=TensorVectorizer(),
+            vectorizer=GoldTensorVectorizationTool(),
         )
         assert gv.collate_fn is pxt_torch_dataset_collate_fn
 
@@ -474,7 +474,7 @@ class TestGoldVectorizer:
 
         gv = GoldVectorizer(
             table_path="unit_test.vectorize_default_collate",
-            vectorizer=TensorVectorizer(),
+            vectorizer=GoldTensorVectorizationTool(),
             collate_fn=custom_collate_fn,
         )
         assert gv.collate_fn is custom_collate_fn
@@ -502,7 +502,7 @@ class TestGoldVectorizer:
 
         gv = GoldVectorizer(
             table_path="unit_test.vectorize_multilabel",
-            vectorizer=TensorVectorizer(),
+            vectorizer=GoldTensorVectorizationTool(),
             data_key="embeddings",
             label_key="label",
             to_keep_schema={"label": pxt.String},
@@ -526,7 +526,7 @@ class TestGoldVectorizer:
 
         gv = GoldVectorizer(
             table_path=table_path,
-            vectorizer=TensorVectorizer(),
+            vectorizer=GoldTensorVectorizationTool(),
             collate_fn=None,
             data_key="embeddings",
             vectorized_key="vectorized",
@@ -560,7 +560,7 @@ class TestGoldVectorizer:
 
         gv = GoldVectorizer(
             table_path=desc_path,
-            vectorizer=TensorVectorizer(),
+            vectorizer=GoldTensorVectorizationTool(),
             collate_fn=None,
             data_key="embeddings",
             vectorized_key="vectorized",
@@ -602,7 +602,7 @@ class TestGoldVectorizer:
 
         gv = GoldVectorizer(
             table_path=desc_path,
-            vectorizer=TensorVectorizer(),
+            vectorizer=GoldTensorVectorizationTool(),
             collate_fn=None,
             data_key="embeddings",
             vectorized_key="vectorized",
@@ -648,7 +648,7 @@ class TestGoldVectorizer:
 
         gv = GoldVectorizer(
             table_path=desc_path,
-            vectorizer=TensorVectorizer(),
+            vectorizer=GoldTensorVectorizationTool(),
             collate_fn=None,
             data_key="embeddings",
             vectorized_key="vectorized",
@@ -696,7 +696,7 @@ class TestGoldVectorizer:
 
         gv = GoldVectorizer(
             table_path=desc_path,
-            vectorizer=TensorVectorizer(),
+            vectorizer=GoldTensorVectorizationTool(),
             collate_fn=None,
             data_key="embeddings",
             vectorized_key="vectorized",
@@ -747,7 +747,7 @@ class TestGoldVectorizer:
 
         gv = GoldVectorizer(
             table_path=desc_path,
-            vectorizer=TensorVectorizer(),
+            vectorizer=GoldTensorVectorizationTool(),
             collate_fn=None,
             data_key="embeddings",
             vectorized_key="vectorized",
@@ -797,7 +797,7 @@ class TestGoldVectorizer:
 
         gv = GoldVectorizer(
             table_path=desc_path,
-            vectorizer=TensorVectorizer(),
+            vectorizer=GoldTensorVectorizationTool(),
             collate_fn=None,
             data_key="embeddings",
             vectorized_key="vectorized",
@@ -825,7 +825,7 @@ class TestGoldVectorizer:
 
         gv = GoldVectorizer(
             table_path="unit_test.vectorize",
-            vectorizer=TensorVectorizer(),
+            vectorizer=GoldTensorVectorizationTool(),
             collate_fn=collate_fn,
             data_key="embeddings",
             vectorized_key="vectorized",
@@ -852,7 +852,7 @@ class TestGoldVectorizer:
     ):
         gv = GoldVectorizer(
             table_path="unit_test.vectorize",
-            vectorizer=TensorVectorizer(),
+            vectorizer=GoldTensorVectorizationTool(),
             collate_fn=lambda x: [d["embeddings"] for d in x],
             data_key="embeddings",
             vectorized_key="vectorized",
@@ -868,7 +868,7 @@ class TestGoldVectorizer:
     ):
         gv = GoldVectorizer(
             table_path="unit_test.vectorize",
-            vectorizer=TensorVectorizer(),
+            vectorizer=GoldTensorVectorizationTool(),
             collate_fn=None,
             data_key="not_present",
             vectorized_key="vectorized",
@@ -884,7 +884,7 @@ class TestGoldVectorizer:
     ):
         gv = GoldVectorizer(
             table_path="unit_test.vectorize",
-            vectorizer=TensorVectorizer(),
+            vectorizer=GoldTensorVectorizationTool(),
             collate_fn=None,
             data_key="embeddings",
             vectorized_key="vectorized",
@@ -908,7 +908,7 @@ class TestGoldVectorizer:
 
         gv = GoldVectorizer(
             table_path=table_path,
-            vectorizer=TensorVectorizer(),
+            vectorizer=GoldTensorVectorizationTool(),
             collate_fn=None,
             data_key="embeddings",
             vectorized_key="vectorized",
@@ -941,7 +941,7 @@ class TestGoldVectorizer:
 
         gv = GoldVectorizer(
             table_path=desc_path,
-            vectorizer=TensorVectorizer(),
+            vectorizer=GoldTensorVectorizationTool(),
             collate_fn=None,
             data_key="embeddings",
             vectorized_key="vectorized",
@@ -965,7 +965,7 @@ class TestGoldVectorizer:
     ):
         gv = GoldVectorizer(
             table_path="unit_test.vectorize",
-            vectorizer=TensorVectorizer(),
+            vectorizer=GoldTensorVectorizationTool(),
             collate_fn=None,
             data_key="embeddings",
             vectorized_key="vectorized",
@@ -994,7 +994,7 @@ class TestGoldVectorizer:
     ):
         gv = GoldVectorizer(
             table_path="unit_test.vectorize",
-            vectorizer=TensorVectorizer(),
+            vectorizer=GoldTensorVectorizationTool(),
             collate_fn=None,
             data_key="embeddings",
             vectorized_key="vectorized",
@@ -1066,8 +1066,8 @@ class TestUnwrapVectorsInBatch:
 
 
 @pytest.fixture
-def vectorizer() -> TensorVectorizer:
-    return TensorVectorizer(channel_pos=2)
+def vectorizer() -> GoldTensorVectorizationTool:
+    return GoldTensorVectorizationTool(channel_pos=2)
 
 
 class TestVectorizeAndUnwrapInBatch:

--- a/tests/vision/test_vision_vectorizers.py
+++ b/tests/vision/test_vision_vectorizers.py
@@ -7,7 +7,11 @@ from goldener.vision.vectorizers import (
     get_vit_prefix_tokens_vectorizer,
     get_vit_patch_tokens_vectorizer,
 )
-from goldener.vectorize import TensorVectorizer, Filter2DWithCount, FilterLocation
+from goldener.vectorize import (
+    GoldTensorVectorizationTool,
+    Filter2DWithCount,
+    FilterLocation,
+)
 
 
 class TestVitVectorizerHelpers:
@@ -26,7 +30,7 @@ class TestVitVectorizerHelpers:
     def test_get_vit_prefix_tokens_vectorizer_default(self):
         x = self.make_tensor((2, 6, 4))
         vec = get_vit_prefix_tokens_vectorizer(n_prefixes=5)
-        assert isinstance(vec, TensorVectorizer)
+        assert isinstance(vec, GoldTensorVectorizationTool)
 
         out = vec.vectorize(x)
         assert out.vectors.shape[0] == x.shape[0] * 5
@@ -86,7 +90,7 @@ class TestVitVectorizerHelpers:
             filter_location=FilterLocation.RANDOM,
             generator=generator,
         )
-        vec = TensorVectorizer(remove=remove, random=rand, channel_pos=2)
+        vec = GoldTensorVectorizationTool(remove=remove, random=rand, channel_pos=2)
 
         out = vec.vectorize(x)
         assert out.vectors.shape[0] == x.shape[0] * 3


### PR DESCRIPTION


Renames `TensorVectorizer` to `GoldTensorVectorizationTool` to follow the `GoldSomethingTool` naming convention used for other embedding-related tools in the library (e.g. `GoldTorchEmbeddingTool`, `GoldSKLearnClusteringTool`).

## Changes

- Renamed the `TensorVectorizer` class in `goldener/vectorize.py`
- Updated all internal usages across `goldener/describe.py` and `goldener/vision/vectorizers.py`
- Updated the exported name in `goldener/__init__.py`
- Updated all references in the test suite
- Updated README.md and the docs/posts (`GOLD_SPLIT.md`, `GOLD_SELECTION.md`, `GOLD_BATCHER.md`)

## Testing

- `pytest` — all tests pass
- `mypy` — no issues
- `ruff check` / `ruff format` — clean

Closes #285

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renames `TensorVectorizer` to `GoldTensorVectorizationTool` to align with the `Gold*Tool` naming used by other embedding tools. The old class name is removed from the public API; behavior, arguments, and outputs are unchanged.

**Migration**
- Update imports:
  - `from goldener import TensorVectorizer` → `from goldener import GoldTensorVectorizationTool`
  - `from goldener.vectorize import TensorVectorizer` → `from goldener.vectorize import GoldTensorVectorizationTool`
- Replace usages: `TensorVectorizer(...)` → `GoldTensorVectorizationTool(...)`
- Update any `isinstance`/type checks from `TensorVectorizer` to `GoldTensorVectorizationTool` (vision helper functions now return the new type).

<sup>Written for commit 767604a3a0df11c108b01a04f8689b9e4c289aaf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/goldener-data/goldener/pull/292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

