### PR TITLE
Use get_random_chunk_assignment in GoldClusterizer chunking process

### DIFF
--- a/goldener/clusterize.py
+++ b/goldener/clusterize.py
@@ -943,30 +943,11 @@ class GoldClusterizer:
             )
             return
 
-        if self.chunk is None or self.chunk >= len(to_cluster_vector_indices):
-            chunk_assignment = [
-                to_cluster_vector_indices,
-            ]
-        else:
-            chunk_count = math.ceil(available_for_clustering / self.chunk)
-            random_assignment = (
-                GoldRandomClusteringTool(random_state=self.random_state)
-                .fit(
-                    torch.empty(
-                        available_for_clustering, 1
-                    ),  # dummy input for random clustering
-                    chunk_count,
-                )
-                .tolist()
-            )
-            chunk_assignment = [
-                [
-                    vector_idx
-                    for vect_pos, vector_idx in enumerate(to_cluster_vector_indices)
-                    if random_assignment[vect_pos] == chunk_idx
-                ]
-                for chunk_idx in range(chunk_count)
-            ]
+        chunk_assignment = get_random_chunk_assignment(
+            to_chunk=to_cluster_vector_indices,
+            max_chunk_size=self.chunk,
+            random_state=self.random_state,
+        )
 
         for chunk_indices in chunk_assignment:
             to_cluster_from = cluster_from.where(


### PR DESCRIPTION
Replaces the manual chunk-assignment logic in `GoldClusterizer._cluster_label` with a call to the existing `get_random_chunk_assignment` function, following the same pattern already used in `GoldSelector`.

This removes duplicated logic — the manual implementation and the shared function performed the exact same steps (chunk-count calculation, random assignment via `GoldRandomClusteringTool`, index grouping). No behavior change.

## Testing
- `pytest` — all tests pass
- `mypy` — no issues

Closes #269

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes chunk assignment in `GoldClusterizer._cluster_label` by using `get_random_chunk_assignment`, removing duplicated logic and aligning behavior with `GoldSelector`. No behavior change; chunk count calculation and random grouping remain the same.

**Review notes**
- Validate `get_random_chunk_assignment` matches prior semantics: single chunk when `chunk is None` or `chunk >= len(indices)`; otherwise `ceil(available/self.chunk)` chunks with grouping driven by `random_state`.
- Confirm `random_state` is passed through to preserve reproducibility.
- No migration required.

<sup>Written for commit fc8fb552430c8e69eb185c97dc5422e1c939666e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/goldener-data/goldener/pull/293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

