### PR TITLE
Update the README.md to make Goldener presentation larger than just sampling and splitting

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A Python library orchestrating data during the full life cycle of Machine Learni
 # Overview
 
 Goldener is an **open-source Python library** (Apache 2 licence) designed to manage the **orchestration
-of data** (sampling, splitting) during the full life cycle of Machine Learning (ML) pipelines.
+of data** during the full life cycle of Machine Learning (ML) pipelines.
 
 In the artificial intelligence (AI) era, the data is the new gold. Being able to collect it is already something
 but **creating value from it is the real challenge**. Goldener is designed to help to make the most of the available data.
@@ -28,12 +28,12 @@ It provides tools to orchestrate data during the full life cycle of Machine Lear
 from the training phase to the monitoring phase.
 
 Goldener makes the **right data** available at the **right time**, allowing to **optimize the performance**
-of any ML pipelines while **minimizing the costs** (time, performance, computing resources) of data sampling and labeling.
+of any ML pipelines while **minimizing the costs** (time, performance, computing resources).
 
-When it's time to annotate data, Goldener find the most representative subset to annotate. During annotation, it can help
+When it's time to annotate data, Goldener finds the most representative subset to annotate. During annotation, it can help
 to define annotation guidelines by spotting specific cases or as well run annotation quality checks.
 Once enough data is annotated, Goldener can split it in multiple sets (train, validation, test) ensuring the reproduction
-of the task variability. During the training phase, Goldener can balance efficiently the data
+of the task variability. During the training phase, Goldener can efficiently balance the data
 to optimize the training time and the model performance. Finally, when the model is deployed, Goldener can find
 the most informative data to monitor the model performance and detect any drift in the data distribution.
 
@@ -49,7 +49,7 @@ the different for different tasks (selection, splitting, monitoring, etc.).
 - **Modality-agnostic**: The same tool is actionable for any data modalities (text, image, video, tabular, etc.)
 and even for multimodality data.
 
-This is not yet applied but for the next iterations, the following principles will be as well followed:
+This is not yet applied, but for the next iterations, the following principles will be as well followed:
 
 - **Distributed first**: Any task can be distributed across multiple machines.
 - **On demand access to pipelines**: All processing pipelines are serializable.


### PR DESCRIPTION
This pull request makes minor improvements to the `README.md` file, focusing on grammar, clarity, and readability of the project overview and principles (less restricted than just sampling and splitting).

- Documentation improvements:
  * Fixed grammatical errors and improved clarity in the project overview section, such as correcting verb tenses and removing redundant phrases.
  * Improved readability and grammar in the section describing future principles, clarifying the intent for upcoming iterations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Broadens the README to present Goldener as a full ML data orchestration library, not just sampling and splitting, and improves grammar for clarity. No code or behavior changes.

- Removes the "(sampling, splitting)" qualifier and generalizes cost-minimization wording.
- Fixes minor grammar and readability issues in the overview and future principles (e.g., “finds,” “efficiently balance,” comma usage).

<sup>Written for commit 498bcc177e1f3d76f58f20ffca9dc44ce2c6a9c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/goldener-data/goldener/pull/294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

