### PR TITLE
Export GoldClusterizedBatchSampler from package root

### DIFF
--- a/goldener/__init__.py
+++ b/goldener/__init__.py
@@ -15,6 +15,7 @@ from goldener.embed import (
     GoldTorchEmbeddingToolConfig,
     GoldMultiModalTorchEmbeddingTool,
 )
+from goldener.organize import GoldClusterizedBatchSampler
 from goldener.pxt_utils import GoldPxtTorchDataset
 from goldener.reduce import (
     GoldReductionTool,
@@ -52,6 +53,7 @@ __all__ = (
     "GoldTorchEmbeddingTool",
     "GoldTorchEmbeddingToolConfig",
     "GoldMultiModalTorchEmbeddingTool",
+    "GoldClusterizedBatchSampler",
     "GoldPxtTorchDataset",
     "GoldReductionTool",
     "GoldReductionToolWithFit",

--- a/tests/test_organize.py
+++ b/tests/test_organize.py
@@ -6,13 +6,13 @@ import pixeltable as pxt
 from goldener import (
     GoldDescriptor,
     GoldClusterizer,
+    GoldClusterizedBatchSampler,
     GoldClusteringTool,
     GoldTorchEmbeddingToolConfig,
     GoldTorchEmbeddingTool,
 )
 from goldener.organize import (
     ExhaustedClusterStrategy,
-    GoldClusterizedBatchSampler,
     get_indices_per_cluster_for_subset,
 )
 from goldener.pxt_utils import pxt_torch_dataset_collate_fn


### PR DESCRIPTION
## Summary

- export `GoldClusterizedBatchSampler` from the `goldener` package root
- include `GoldClusterizedBatchSampler` in `goldener.__all__`
- exercise the public import through the existing sampler tests

## Testing

- `pytest tests -q -p no:cacheprovider` — 431 passed
- `mypy .` — success
- `ruff check .` — success
- `ruff format --check .` — success

Closes #221


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `GoldClusterizedBatchSampler` importable from the `goldener` package root to simplify the public API. Previously: `from goldener.organize import GoldClusterizedBatchSampler`. Now: `from goldener import GoldClusterizedBatchSampler`. This adds the symbol to `goldener.__all__` with no runtime behavior change; existing imports continue to work.

**Review notes**
- Re-exported via `goldener.__init__` and included in `__all__`.
- Updated tests to import from `goldener` to exercise the public API.

**Migration**
- No action required. Optionally switch imports to `from goldener import GoldClusterizedBatchSampler`.

<sup>Written for commit 4e8a636267b3e37b61cdd5c1d7a2cf7478faef27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/goldener-data/goldener/pull/302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

