### PR TITLE
Display an estimation of the computation time for GoldVectorizer

### DIFF
--- a/goldener/vectorize.py
+++ b/goldener/vectorize.py
@@ -554,6 +554,12 @@ class GoldVectorizer:
             distribute: Whether to use distributed processing. Defaults to False.
             drop_table: Whether to drop the table after dataset creation. Defaults to False.
             max_batches: Optional maximum number of batches to process.
+            estimation_time_batch_count: Number of initial batches used to estimate the total
+                computation time. Defaults to 2.
+
+        Raises:
+            NotImplementedError: If `distribute` is True.
+            ValueError: If `estimation_time_batch_count` is not a positive integer.
         """
         self.table_path = table_path
         self.vectorizer = vectorizer
@@ -600,6 +606,7 @@ class GoldVectorizer:
 
         Raises:
             NotImplementedError: If `value` is True.
+
         """
         if value:
             raise NotImplementedError(
@@ -884,7 +891,7 @@ class GoldVectorizer:
         not_empty: bool,
         already_vectorized: set[int],
         restrict_to: set[int] | None = None,
-    ) -> tuple[list[dict[str, Any]] | None, int]:
+    ) -> tuple[list[dict[str, Any]], int]:
         """Process a single batch: assign indices, filter, vectorize, and prepare for insertion."""
         if "idx" not in batch:
             starts = batch_idx * self.batch_size
@@ -899,12 +906,12 @@ class GoldVectorizer:
                 batch = filter_batch_from_indices(batch, to_remove)
 
                 if len(batch) == 0:
-                    return None, start_idx
+                    return [], start_idx
 
         if not_empty:
             batch = filter_batch_from_indices(batch, already_vectorized)
-            if len(batch) == 0:
-                return None, start_idx
+            if not batch:
+                return [], start_idx
 
         already_vectorized.update(
             [
@@ -932,7 +939,7 @@ class GoldVectorizer:
         )
 
         if not batch:
-            return None, start_idx
+            return [], start_idx
 
         start_idx = max(batch["idx_vector"]) + 1
 
@@ -1015,7 +1022,7 @@ class GoldVectorizer:
                 batch, batch_idx, start_idx, not_empty, already_vectorized, restrict_to
             )
 
-            if batch_as_list is None:
+            if not batch_as_list:
                 continue
 
             ready_to_insert.extend(batch_as_list)

--- a/goldener/vectorize.py
+++ b/goldener/vectorize.py
@@ -1,5 +1,6 @@
 import math
 import time
+from itertools import islice
 from dataclasses import dataclass
 from functools import partial
 from logging import getLogger
@@ -574,9 +575,18 @@ class GoldVectorizer:
         self.batch_size = batch_size
         self.num_workers = num_workers
         self.allow_existing = allow_existing
-        self.distribute = distribute
+        if distribute:
+            raise NotImplementedError(
+                "Distributed processing is not implemented for GoldVectorizer."
+            )
+        self._distribute = distribute
         self.drop_table = drop_table
         self.max_batches = max_batches
+        if (
+            not isinstance(estimation_time_batch_count, int)
+            or estimation_time_batch_count <= 0
+        ):
+            raise ValueError("estimation_time_batch_count must be a positive integer.")
         self.estimation_time_batch_count = estimation_time_batch_count
 
     @property
@@ -875,11 +885,7 @@ class GoldVectorizer:
         already_vectorized: set[int],
         restrict_to: set[int] | None = None,
     ) -> tuple[list[dict[str, Any]] | None, int]:
-        """Process a single batch: assign indices, filter, vectorize, and prepare for insertion.
-
-        This factors out the per-batch processing shared by `_sequential_vectorize` and
-        `estimate_computation_time`, so both paths run the exact same vectorization logic.
-        """
+        """Process a single batch: assign indices, filter, vectorize, and prepare for insertion."""
         if "idx" not in batch:
             starts = batch_idx * self.batch_size
             batch["idx"] = [starts + idx for idx in range(len(batch[self.data_key]))]
@@ -1038,22 +1044,15 @@ class GoldVectorizer:
         )
 
         start_idx = 0
+        batch_idx = 0
         already_vectorized: set[int] = set()
-        elapsed = 0.0
         batches_measured = 0
 
-        iterator = enumerate(dataloader)
-        for _ in range(self.estimation_time_batch_count):
-            start = time.perf_counter()
-            try:
-                batch_idx, batch = next(iterator)
-            except StopIteration:
-                break
-            _, start_idx = self._compute_batch(
-                batch, batch_idx, start_idx, False, already_vectorized
-            )
-            elapsed += time.perf_counter() - start
+        start = time.perf_counter()
+        for batch in islice(dataloader, self.estimation_time_batch_count):
+            self._compute_batch(batch, batch_idx, start_idx, False, already_vectorized)
             batches_measured += 1
+        elapsed = time.perf_counter() - start
 
         if batches_measured == 0:
             return None
@@ -1064,7 +1063,9 @@ class GoldVectorizer:
             total_batches = math.ceil(len(dataset) / self.batch_size)
             return avg_time_per_batch * total_batches
 
-        logger.info(f"Average computation time per batch: {avg_time_per_batch:.4f}s")
+        logger.info(
+            f"Goldvectorizer: average computation time per batch: {avg_time_per_batch:.4f}s"
+        )
         return None
 
 

--- a/goldener/vectorize.py
+++ b/goldener/vectorize.py
@@ -11,7 +11,6 @@ from typing_extensions import assert_never
 from typing import Callable, Any
 
 from enum import Enum
-
 import torch
 from torch import Generator
 
@@ -525,6 +524,7 @@ class GoldVectorizer:
         distribute: bool = False,
         drop_table: bool = False,
         max_batches: int | None = None,
+        estimation_time_batch_count: int = 2,
     ) -> None:
         """Initialize the GoldVectorizer.
 
@@ -550,9 +550,6 @@ class GoldVectorizer:
             distribute: Whether to use distributed processing. Defaults to False.
             drop_table: Whether to drop the table after dataset creation. Defaults to False.
             max_batches: Optional maximum number of batches to process.
-
-        Raises:
-            NotImplementedError: If `distribute` is True.
         """
         self.table_path = table_path
         self.vectorizer = vectorizer
@@ -572,13 +569,10 @@ class GoldVectorizer:
         self.batch_size = batch_size
         self.num_workers = num_workers
         self.allow_existing = allow_existing
-        if distribute:
-            raise NotImplementedError(
-                "Distributed processing is not implemented for GoldVectorizer."
-            )
-        self._distribute = distribute
+        self.distribute = distribute
         self.drop_table = drop_table
         self.max_batches = max_batches
+        self.estimation_time_batch_count = estimation_time_batch_count
 
     @property
     def distribute(self) -> bool:
@@ -849,6 +843,63 @@ class GoldVectorizer:
         """
         raise NotImplementedError("Distributed Vectorization is not implemented yet.")
 
+    def _compute_batch(
+        self,
+        batch: dict[str, Any],
+        batch_idx: int,
+        start_idx: int,
+        not_empty: bool,
+        already_vectorized: set[int],
+    ) -> tuple[list[dict[str, Any]] | None, int]:
+        """Process a single batch: assign indices, filter, vectorize, and prepare for insertion.
+
+        This factors out the per-batch processing shared by `_sequential_vectorize` and
+        `estimate_computation_time`, so both paths run the exact same vectorization logic.
+        """
+        if "idx" not in batch:
+            starts = batch_idx * self.batch_size
+            batch["idx"] = [starts + idx for idx in range(len(batch[self.data_key]))]
+
+        if not_empty:
+            batch = filter_batch_from_indices(batch, already_vectorized)
+            if len(batch) == 0:
+                return None, start_idx
+
+        already_vectorized.update(
+            [
+                int(idx.item()) if isinstance(idx, torch.Tensor) else int(idx)
+                for idx in batch["idx"]
+            ]
+        )
+
+        to_keep_keys = (
+            list(self.to_keep_schema.keys()) if self.to_keep_schema is not None else []
+        )
+        batch = vectorize_and_unwrap_in_batch(
+            batch=batch,
+            vectorizer=self.vectorizer,
+            data_key=self.data_key,
+            vectorized_key=self.vectorized_key,
+            target_key=self.target_key,
+            to_keep=to_keep_keys,
+            starts=start_idx,
+            target_to_label=self.target_to_label,
+            merge_multilabels=self.merge_multilabels,
+            label_key=self.label_key,
+            exclude_full_zero_target=self.exclude_full_zero_target,
+            exclude_labels=self.exclude_labels,
+        )
+
+        if not batch:
+            return None, start_idx
+
+        start_idx = max(batch["idx_vector"]) + 1
+
+        to_insert_keys = [self.vectorized_key, "idx"] + to_keep_keys
+        batch_as_list = make_batch_ready_for_table(batch, to_insert_keys, "idx_vector")
+
+        return batch_as_list, start_idx
+
     def _sequential_vectorize(
         self,
         vectorized_table: Table,
@@ -917,62 +968,12 @@ class GoldVectorizer:
             if self.max_batches is not None and batch_idx >= self.max_batches:
                 break
 
-            # add idx if it is not provided by the dataset
-            if "idx" not in batch:
-                starts = batch_idx * self.batch_size
-                batch["idx"] = [
-                    starts + idx for idx in range(len(batch[self.data_key]))
-                ]
-
-            # Keep only not yet described samples in the batch
-            if not_empty:
-                batch = filter_batch_from_indices(
-                    batch,
-                    already_vectorized,
-                )
-
-                if len(batch) == 0:
-                    continue  # all samples already described
-
-            already_vectorized.update(
-                [
-                    idx.item() if isinstance(idx, torch.Tensor) else idx
-                    for idx in batch["idx"]
-                ]
+            batch_as_list, start_idx = self._compute_batch(
+                batch, batch_idx, start_idx, not_empty, already_vectorized
             )
 
-            # vectorize data
-            to_keep_keys = (
-                list(self.to_keep_schema.keys())
-                if self.to_keep_schema is not None
-                else []
-            )
-            batch = vectorize_and_unwrap_in_batch(
-                batch=batch,
-                vectorizer=self.vectorizer,
-                data_key=self.data_key,
-                vectorized_key=self.vectorized_key,
-                target_key=self.target_key,
-                to_keep=to_keep_keys,
-                starts=start_idx,
-                target_to_label=self.target_to_label,
-                merge_multilabels=self.merge_multilabels,
-                label_key=self.label_key,
-                exclude_full_zero_target=self.exclude_full_zero_target,
-                exclude_labels=self.exclude_labels,
-            )
-
-            if not batch:
+            if batch_as_list is None:
                 continue
-
-            start_idx = max(batch["idx_vector"]) + 1
-
-            to_insert_keys = [self.vectorized_key, "idx"] + to_keep_keys
-            batch_as_list = make_batch_ready_for_table(
-                batch,
-                to_insert_keys,
-                "idx_vector",
-            )
 
             ready_to_insert.extend(batch_as_list)
             if len(ready_to_insert) >= self.min_pxt_insert_size:
@@ -984,54 +985,50 @@ class GoldVectorizer:
 
         return vectorized_table
 
+    def estimate_computation_time(self, dataset: Dataset) -> float | None:
+        """Estimate the total computation time for vectorizing a dataset.
 
-def estimate_vectorization_time(
-    vectorizer: GoldVectorizer,
-    dataset: Dataset,
-    sample_batches: int = 2,
-) -> float | None:
-    """Estimate the total vectorization time for a dataset by timing a small sample of batches.
+        Times `self.estimation_time_batch_count` initial batches — including data loading,
+        preprocessing, and vectorization — running the exact same steps as
+        `_sequential_vectorize` (via `_compute_batch`), then extrapolates if the dataset's
+        size is known.
+        """
+        dataloader = DataLoader(
+            dataset,
+            batch_size=self.batch_size,
+            num_workers=self.num_workers,
+            collate_fn=self.collate_fn,
+        )
 
-    Args:
-        vectorizer: The GoldVectorizer whose configuration (batch size, workers, etc.)
-            will be used to sample and time batches.
-        dataset: The dataset to estimate vectorization time for.
-        sample_batches: Number of initial batches to measure. Defaults to 2.
+        start_idx = 0
+        already_vectorized: set[int] = set()
+        elapsed = 0.0
+        batches_measured = 0
 
-    Returns:
-        The estimated total vectorization time in seconds, or None if the dataset's
-        size is unknown (only the per-batch time is logged in that case).
-    """
-    dataloader = DataLoader(
-        dataset,
-        batch_size=vectorizer.batch_size,
-        num_workers=vectorizer.num_workers,
-        collate_fn=vectorizer.collate_fn,
-    )
+        iterator = enumerate(dataloader)
+        for _ in range(self.estimation_time_batch_count):
+            start = time.perf_counter()
+            try:
+                batch_idx, batch = next(iterator)
+            except StopIteration:
+                break
+            _, start_idx = self._compute_batch(
+                batch, batch_idx, start_idx, False, already_vectorized
+            )
+            elapsed += time.perf_counter() - start
+            batches_measured += 1
 
-    elapsed = 0.0
-    batches_measured = 0
+        if batches_measured == 0:
+            return None
 
-    for batch_idx, batch in enumerate(dataloader):
-        if batch_idx >= sample_batches:
-            break
+        avg_time_per_batch = elapsed / batches_measured
 
-        start = time.perf_counter()
-        vectorizer.vectorizer.vectorize(batch[vectorizer.data_key])
-        elapsed += time.perf_counter() - start
-        batches_measured += 1
+        if hasattr(dataset, "__len__"):
+            total_batches = math.ceil(len(dataset) / self.batch_size)
+            return avg_time_per_batch * total_batches
 
-    if batches_measured == 0:
+        logger.info(f"Average computation time per batch: {avg_time_per_batch:.4f}s")
         return None
-
-    avg_time_per_batch = elapsed / batches_measured
-
-    if hasattr(dataset, "__len__"):
-        total_batches = math.ceil(len(dataset) / vectorizer.batch_size)
-        return avg_time_per_batch * total_batches
-
-    logger.info(f"Average vectorization time per batch: {avg_time_per_batch:.4f}s")
-    return None
 
 
 def unwrap_vectors_in_batch(

--- a/goldener/vectorize.py
+++ b/goldener/vectorize.py
@@ -1,3 +1,5 @@
+import math
+import time
 from dataclasses import dataclass
 from functools import partial
 from logging import getLogger
@@ -956,6 +958,55 @@ class GoldVectorizer:
             vectorized_table.batch_update(ready_to_insert, if_not_exists="insert")
 
         return vectorized_table
+
+
+def estimate_vectorization_time(
+    vectorizer: GoldVectorizer,
+    dataset: Dataset,
+    sample_batches: int = 2,
+) -> float | None:
+    """Estimate the total vectorization time for a dataset by timing a small sample of batches.
+
+    Args:
+        vectorizer: The GoldVectorizer whose configuration (batch size, workers, etc.)
+            will be used to sample and time batches.
+        dataset: The dataset to estimate vectorization time for.
+        sample_batches: Number of initial batches to measure. Defaults to 2.
+
+    Returns:
+        The estimated total vectorization time in seconds, or None if the dataset's
+        size is unknown (only the per-batch time is logged in that case).
+    """
+    dataloader = DataLoader(
+        dataset,
+        batch_size=vectorizer.batch_size,
+        num_workers=vectorizer.num_workers,
+        collate_fn=vectorizer.collate_fn,
+    )
+
+    elapsed = 0.0
+    batches_measured = 0
+
+    for batch_idx, batch in enumerate(dataloader):
+        if batch_idx >= sample_batches:
+            break
+
+        start = time.perf_counter()
+        vectorizer.vectorizer.vectorize(batch[vectorizer.data_key])
+        elapsed += time.perf_counter() - start
+        batches_measured += 1
+
+    if batches_measured == 0:
+        return None
+
+    avg_time_per_batch = elapsed / batches_measured
+
+    if hasattr(dataset, "__len__"):
+        total_batches = math.ceil(len(dataset) / vectorizer.batch_size)
+        return avg_time_per_batch * total_batches
+
+    logger.info(f"Average vectorization time per batch: {avg_time_per_batch:.4f}s")
+    return None
 
 
 def unwrap_vectors_in_batch(

--- a/tests/test_vectorize.py
+++ b/tests/test_vectorize.py
@@ -10,6 +10,7 @@ from goldener.vectorize import (
     FilterLocation,
     GoldVectorizer,
     Vectorized,
+    estimate_vectorization_time,
     unwrap_vectors_in_batch,
     vectorize_and_unwrap_in_batch,
 )
@@ -1160,3 +1161,60 @@ class TestVectorizeAndUnwrapInBatch:
         )
         vectors = result["vectorized"]
         assert len(vectors) == 2
+
+
+class TestEstimateVectorizationTime:
+    def setup_method(self):
+        pxt.drop_dir("unit_test", force=True)
+        pxt.create_dir("unit_test", if_exists="ignore")
+
+    def teardown_method(self):
+        pxt.drop_dir("unit_test", force=True)
+
+    def test_returns_estimate_when_dataset_size_known(self):
+        gv = GoldVectorizer(
+            table_path="unit_test.vectorize_estimate",
+            vectorizer=GoldTensorVectorizationTool(),
+            batch_size=2,
+        )
+        dataset = DummyDataset(dataset_len=10)
+
+        estimate = estimate_vectorization_time(gv, dataset, sample_batches=2)
+
+        assert estimate is not None
+        assert estimate > 0
+
+    def test_returns_none_when_dataset_size_unknown(self):
+        from torch.utils.data import IterableDataset
+
+        class NoLenDataset(IterableDataset):
+            def __init__(self):
+                self.data = [
+                    {"embeddings": torch.zeros(3, 8, 8), "idx": i, "label": "dummy"}
+                    for i in range(4)
+                ]
+
+            def __iter__(self):
+                return iter(self.data)
+
+        gv = GoldVectorizer(
+            table_path="unit_test.vectorize_estimate_nolen",
+            vectorizer=GoldTensorVectorizationTool(),
+            batch_size=2,
+        )
+
+        estimate = estimate_vectorization_time(gv, NoLenDataset(), sample_batches=2)
+
+        assert estimate is None
+
+    def test_returns_none_when_dataset_is_empty(self):
+        gv = GoldVectorizer(
+            table_path="unit_test.vectorize_estimate_empty",
+            vectorizer=GoldTensorVectorizationTool(),
+            batch_size=2,
+        )
+        dataset = DummyDataset(dataset_len=0)
+
+        estimate = estimate_vectorization_time(gv, dataset, sample_batches=2)
+
+        assert estimate is None

--- a/tests/test_vectorize.py
+++ b/tests/test_vectorize.py
@@ -10,7 +10,6 @@ from goldener.vectorize import (
     FilterLocation,
     GoldVectorizer,
     Vectorized,
-    estimate_vectorization_time,
     unwrap_vectors_in_batch,
     vectorize_and_unwrap_in_batch,
 )
@@ -1182,7 +1181,7 @@ class TestVectorizeAndUnwrapInBatch:
         assert len(vectors) == 2
 
 
-class TestEstimateVectorizationTime:
+class TestEstimateComputationTime:
     def setup_method(self):
         pxt.drop_dir("unit_test", force=True)
         pxt.create_dir("unit_test", if_exists="ignore")
@@ -1198,7 +1197,7 @@ class TestEstimateVectorizationTime:
         )
         dataset = DummyDataset(dataset_len=10)
 
-        estimate = estimate_vectorization_time(gv, dataset, sample_batches=2)
+        estimate = gv.estimate_computation_time(dataset)
 
         assert estimate is not None
         assert estimate > 0
@@ -1222,7 +1221,7 @@ class TestEstimateVectorizationTime:
             batch_size=2,
         )
 
-        estimate = estimate_vectorization_time(gv, NoLenDataset(), sample_batches=2)
+        estimate = gv.estimate_computation_time(NoLenDataset())
 
         assert estimate is None
 
@@ -1234,6 +1233,6 @@ class TestEstimateVectorizationTime:
         )
         dataset = DummyDataset(dataset_len=0)
 
-        estimate = estimate_vectorization_time(gv, dataset, sample_batches=2)
+        estimate = gv.estimate_computation_time(dataset)
 
         assert estimate is None

--- a/tests/test_vectorize.py
+++ b/tests/test_vectorize.py
@@ -481,6 +481,16 @@ class TestGoldVectorizer:
             vectorizer.distribute = True
         assert vectorizer.distribute is False
 
+    def test_estimation_time_batch_count_must_be_positive(self):
+        with pytest.raises(
+            ValueError, match="estimation_time_batch_count must be a positive integer"
+        ):
+            GoldVectorizer(
+                table_path="unit_test.test_estimation_time_batch_count",
+                vectorizer=GoldTensorVectorizationTool(),
+                estimation_time_batch_count=0,
+            )
+
     def test_collate_fn_defaults_to_collate_keeping_sequences_as_sequences(self):
         gv = GoldVectorizer(
             table_path="unit_test.vectorize_default_collate",


### PR DESCRIPTION
Adds `estimate_vectorization_time`, a utility function that estimates the total vectorization time for a dataset by timing a small sample of the first batches (default: 2).

- If the dataset's size is known (`__len__` available), extrapolates and returns the total estimated time.
- If not, logs the average time per batch and returns `None`, as discussed in the issue.

## Note
While writing tests, found that a map-style dataset (with `__getitem__` but no `__len__`) isn't a valid PyTorch construct — the default `DataLoader` sampler requires `__len__` regardless. A dataset with unknown size needs to be an `IterableDataset` instead, which is how the "unknown size" test case is now implemented, matching how `GoldPxtTorchDataset` already works in the real codebase.

## Testing
- `pytest` — all tests pass (434 passed)
- `mypy` — no issues

Closes #290

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `estimate_computation_time` to `GoldVectorizer`, which predicts total vectorization runtime by timing a small sample of initial batches (default 2, configurable via `estimation_time_batch_count`). Previously there was no way to estimate duration; now known-size datasets get a total-time estimate in seconds, while unknown-size datasets (e.g., `IterableDataset`) log the average per-batch time and return `None`. Per-batch processing is now shared between estimation and sequential vectorization via `_compute_batch`.

- Returns `None` when no batches are measured (empty dataset); `estimation_time_batch_count` must be a positive integer or `ValueError` is raised.
- `_sequential_vectorize` now delegates to `_compute_batch` with no behavior change.
- Enabling `distribute` still raises `NotImplementedError`.

Closes #290.

<sup>Written for commit 67e318f55096414aa32d1a3a0e56f35e523dcd2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/goldener-data/goldener/pull/305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

