### PR TITLE
fix: force `GoldClusterizer` to cluster every sample in 1 unique

### DIFF
--- a/goldener/clusterize.py
+++ b/goldener/clusterize.py
@@ -254,7 +254,8 @@ class GoldClusterizer:
         max_batches: Optional maximum number of batches to process. Useful for testing on a small subset of the dataset.
         random_state: Optional random state for reproducibility during chunk assignment.
         force_same_cluster: If True, all vectors from the same sample (same `idx`) are assigned
-            to the same cluster. Default is False.
+            to the same cluster. The assignment to a cluster depends on the last clusterized vector
+            of the sample (suboptimal but easiest solution). Default is False.
     """
 
     _MINIMAL_SCHEMA: dict[str, type] = {
@@ -312,7 +313,8 @@ class GoldClusterizer:
             max_batches: Optional maximum number of batches to process. Useful for testing on a small subset of the dataset.
             random_state: Optional random state for reproducibility during chunk assignment.
             force_same_cluster: If True, all vectors from the same sample (same `idx`) are assigned
-                to the same cluster. Default is False.
+                to the same cluster. The assignment to a cluster depends on the last clusterized vector
+                of the sample (suboptimal but easiest solution). Default is False.
 
         Raises:
             ValueError: If `chunk` is not a positive integer or None.
@@ -955,14 +957,10 @@ class GoldClusterizer:
             random_state=self.random_state,
         )
 
-        idx_key = "idx" if self.force_same_cluster else "idx_vector"
-        idx_col = get_expr_from_column_name(cluster_from, idx_key)
-        idx_expr = get_expr_from_column_name(cluster_table, idx_key)
-
         for chunk_indices in chunk_assignment:
             to_cluster_from = cluster_from.where(
                 cluster_from.idx_vector.isin(chunk_indices)
-            ).select(vectorized_col, idx_col)
+            ).select(vectorized_col, cluster_from.idx_vector)
 
             if to_cluster_from.count() == 0:
                 raise ValueError("Unexpected empty chunk for clustering.")
@@ -970,7 +968,7 @@ class GoldClusterizer:
             to_cluster_for_chunk = [
                 (
                     torch.from_numpy(sample[self.vectorized_key]),
-                    torch.tensor(sample[idx_key]).unsqueeze(0),
+                    torch.tensor(sample["idx_vector"]).unsqueeze(0),
                 )
                 for sample in to_cluster_from.collect()
             ]
@@ -993,7 +991,11 @@ class GoldClusterizer:
                 set_value_to_idx_rows(
                     table=cluster_table,
                     col_expr=cluster_col,
-                    idx_expr=idx_expr,
+                    idx_expr=(
+                        cluster_table.idx
+                        if self.force_same_cluster
+                        else cluster_table.idx_vector
+                    ),
                     indices=set(indices_in_cluster),
                     value=cluster_idx,
                 )

--- a/goldener/clusterize.py
+++ b/goldener/clusterize.py
@@ -929,6 +929,9 @@ class GoldClusterizer:
         """
         cluster_col = get_expr_from_column_name(cluster_table, self.cluster_key)
         vectorized_col = get_expr_from_column_name(cluster_from, self.vectorized_key)
+        idx_key = "idx" if self.force_same_cluster else "idx_vector"
+        source_idx_col = get_expr_from_column_name(cluster_from, idx_key)
+        cluster_idx_col = get_expr_from_column_name(cluster_table, idx_key)
 
         if label_value is not None:
             assert self.label_key is not None
@@ -960,7 +963,7 @@ class GoldClusterizer:
         for chunk_indices in chunk_assignment:
             to_cluster_from = cluster_from.where(
                 cluster_from.idx_vector.isin(chunk_indices)
-            ).select(vectorized_col, cluster_from.idx_vector)
+            ).select(vectorized_col, source_idx_col)
 
             if to_cluster_from.count() == 0:
                 raise ValueError("Unexpected empty chunk for clustering.")
@@ -968,7 +971,7 @@ class GoldClusterizer:
             to_cluster_for_chunk = [
                 (
                     torch.from_numpy(sample[self.vectorized_key]),
-                    torch.tensor(sample["idx_vector"]).unsqueeze(0),
+                    torch.tensor(sample[idx_key]).unsqueeze(0),
                 )
                 for sample in to_cluster_from.collect()
             ]
@@ -991,11 +994,7 @@ class GoldClusterizer:
                 set_value_to_idx_rows(
                     table=cluster_table,
                     col_expr=cluster_col,
-                    idx_expr=(
-                        cluster_table.idx
-                        if self.force_same_cluster
-                        else cluster_table.idx_vector
-                    ),
+                    idx_expr=cluster_idx_col,
                     indices=set(indices_in_cluster),
                     value=cluster_idx,
                 )

--- a/goldener/clusterize.py
+++ b/goldener/clusterize.py
@@ -253,6 +253,8 @@ class GoldClusterizer:
             when using `cluster_in_dataset`. Default is False.
         max_batches: Optional maximum number of batches to process. Useful for testing on a small subset of the dataset.
         random_state: Optional random state for reproducibility during chunk assignment.
+        force_same_cluster: If True, all vectors from the same sample (same `idx`) are assigned
+            to the same cluster. Default is False.
     """
 
     _MINIMAL_SCHEMA: dict[str, type] = {
@@ -280,6 +282,7 @@ class GoldClusterizer:
         drop_table: bool = False,
         max_batches: int | None = None,
         random_state: int | None = None,
+        force_same_cluster: bool = False,
     ) -> None:
         """Initialize the GoldClusterizer with configuration parameters.
 
@@ -308,6 +311,8 @@ class GoldClusterizer:
                 when using `cluster_in_dataset`. Default is False.
             max_batches: Optional maximum number of batches to process. Useful for testing on a small subset of the dataset.
             random_state: Optional random state for reproducibility during chunk assignment.
+            force_same_cluster: If True, all vectors from the same sample (same `idx`) are assigned
+                to the same cluster. Default is False.
 
         Raises:
             ValueError: If `chunk` is not a positive integer or None.
@@ -334,6 +339,7 @@ class GoldClusterizer:
         self.drop_table = drop_table
         self.max_batches = max_batches
         self.random_state = random_state
+        self.force_same_cluster = force_same_cluster
 
     def cluster_in_dataset(
         self, cluster_from: Dataset | Table, n_clusters: int
@@ -949,10 +955,14 @@ class GoldClusterizer:
             random_state=self.random_state,
         )
 
+        idx_key = "idx" if self.force_same_cluster else "idx_vector"
+        idx_col = get_expr_from_column_name(cluster_from, idx_key)
+        idx_expr = get_expr_from_column_name(cluster_table, idx_key)
+
         for chunk_indices in chunk_assignment:
             to_cluster_from = cluster_from.where(
                 cluster_from.idx_vector.isin(chunk_indices)
-            ).select(vectorized_col, cluster_from.idx_vector)
+            ).select(vectorized_col, idx_col)
 
             if to_cluster_from.count() == 0:
                 raise ValueError("Unexpected empty chunk for clustering.")
@@ -960,7 +970,7 @@ class GoldClusterizer:
             to_cluster_for_chunk = [
                 (
                     torch.from_numpy(sample[self.vectorized_key]),
-                    torch.tensor(sample["idx_vector"]).unsqueeze(0),
+                    torch.tensor(sample[idx_key]).unsqueeze(0),
                 )
                 for sample in to_cluster_from.collect()
             ]
@@ -983,7 +993,7 @@ class GoldClusterizer:
                 set_value_to_idx_rows(
                     table=cluster_table,
                     col_expr=cluster_col,
-                    idx_expr=cluster_table.idx_vector,
+                    idx_expr=idx_expr,
                     indices=set(indices_in_cluster),
                     value=cluster_idx,
                 )

--- a/tests/test_clusterize.py
+++ b/tests/test_clusterize.py
@@ -560,51 +560,20 @@ class TestGoldClusterizer:
 
         assert cluster_table.count() == 30
 
-        sample_clusters: dict[int, set] = {}
-        for row in cluster_table.select(
-            cluster_table.idx, cluster_table[clusterizer.cluster_key]
-        ).collect():
-            assert row[clusterizer.cluster_key] is not None
-            sample_clusters.setdefault(row["idx"], set()).add(
-                row[clusterizer.cluster_key]
+        samples_by_cluster = [
+            clusterizer.get_cluster_indices(
+                cluster_table,
+                cluster_key=clusterizer.cluster_key,
+                cluster_idx=cluster_idx,
+                idx_key="idx",
             )
-
-        assert set(sample_clusters) == set(range(10))
-        assert all(len(clusters) == 1 for clusters in sample_clusters.values())
-
-    def test_cluster_in_table_without_force_keeps_per_vector_labels(self):
-        src_path = "unit_test.src_cluster_no_force_table"
-        cluster_path = "unit_test.test_cluster_no_force"
-
-        rows = [
-            {
-                "idx": sample,
-                "idx_vector": sample * 3 + vector,
-                "vectorized": torch.rand(4).numpy(),
-            }
-            for sample in range(10)
-            for vector in range(3)
+            for cluster_idx in range(4)
         ]
-        src_table = pxt.create_table(src_path, source=rows, if_exists="replace_force")
-
-        clusterizer = GoldClusterizer(
-            table_path=cluster_path,
-            clustering_tool=GoldRandomClusteringTool(random_state=0),
-            allow_existing=True,
-        )
-
-        cluster_table = clusterizer.cluster_in_table(src_table, n_clusters=4)
-
-        assert cluster_table.count() == 30
-        labeled_vectors = (
-            cluster_table.where(
-                cluster_table[clusterizer.cluster_key] != None  # noqa: E711
-            )
-            .select(cluster_table.idx_vector)
-            .distinct()
-            .count()
-        )
-        assert labeled_vectors == 30
+        seen_samples: set[int] = set()
+        for samples in samples_by_cluster:
+            assert seen_samples.isdisjoint(samples)
+            seen_samples.update(samples)
+        assert seen_samples == set(range(10))
 
     def test_cluster_in_table_with_reducer(self):
         table_path = "unit_test.test_cluster_reducer"

--- a/tests/test_clusterize.py
+++ b/tests/test_clusterize.py
@@ -533,6 +533,79 @@ class TestGoldClusterizer:
         ]
         assert set(distinct_clusters).issubset(set(range(3)))
 
+    def test_cluster_in_table_force_same_cluster(self):
+        src_path = "unit_test.src_cluster_force_table"
+        cluster_path = "unit_test.test_cluster_force_same"
+
+        rows = [
+            {
+                "idx": sample,
+                "idx_vector": sample * 3 + vector,
+                "vectorized": torch.rand(4).numpy(),
+            }
+            for sample in range(10)
+            for vector in range(3)
+        ]
+        src_table = pxt.create_table(src_path, source=rows, if_exists="replace_force")
+
+        clusterizer = GoldClusterizer(
+            table_path=cluster_path,
+            clustering_tool=GoldRandomClusteringTool(random_state=0),
+            allow_existing=True,
+            chunk=10,
+            force_same_cluster=True,
+        )
+
+        cluster_table = clusterizer.cluster_in_table(src_table, n_clusters=4)
+
+        assert cluster_table.count() == 30
+
+        sample_clusters: dict[int, set] = {}
+        for row in cluster_table.select(
+            cluster_table.idx, cluster_table[clusterizer.cluster_key]
+        ).collect():
+            assert row[clusterizer.cluster_key] is not None
+            sample_clusters.setdefault(row["idx"], set()).add(
+                row[clusterizer.cluster_key]
+            )
+
+        assert set(sample_clusters) == set(range(10))
+        assert all(len(clusters) == 1 for clusters in sample_clusters.values())
+
+    def test_cluster_in_table_without_force_keeps_per_vector_labels(self):
+        src_path = "unit_test.src_cluster_no_force_table"
+        cluster_path = "unit_test.test_cluster_no_force"
+
+        rows = [
+            {
+                "idx": sample,
+                "idx_vector": sample * 3 + vector,
+                "vectorized": torch.rand(4).numpy(),
+            }
+            for sample in range(10)
+            for vector in range(3)
+        ]
+        src_table = pxt.create_table(src_path, source=rows, if_exists="replace_force")
+
+        clusterizer = GoldClusterizer(
+            table_path=cluster_path,
+            clustering_tool=GoldRandomClusteringTool(random_state=0),
+            allow_existing=True,
+        )
+
+        cluster_table = clusterizer.cluster_in_table(src_table, n_clusters=4)
+
+        assert cluster_table.count() == 30
+        labeled_vectors = (
+            cluster_table.where(
+                cluster_table[clusterizer.cluster_key] != None  # noqa: E711
+            )
+            .select(cluster_table.idx_vector)
+            .distinct()
+            .count()
+        )
+        assert labeled_vectors == 30
+
     def test_cluster_in_table_with_reducer(self):
         table_path = "unit_test.test_cluster_reducer"
 


### PR DESCRIPTION
Fixes #226

Added a `force_same_cluster` boolean parameter to `GoldClusterizer` (default `False`); when enabled, `_cluster_label` maps vector indices to sample `idx` values and updates all rows for each sample so every vector from the same sample shares one cluster.

Local tests pass.

---
This change was prepared with AI assistance under human direction and review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #226 by adding an opt-in flag so `GoldClusterizer` assigns one cluster per sample instead of per vector. When enabled, all vectors of a sample (`idx`) share the label of the last processed vector of that sample.

- New parameter `force_same_cluster=False`; when True, `_cluster_label` keys off `idx` instead of `idx_vector`.
- Side effect: a sample’s final label depends on processing order; later vectors can overwrite earlier labels.
- Migration: the `idx` column must exist in both `cluster_from` and `cluster_table` before enabling.
- Default behavior unchanged; enabling removes within-sample label variance.

<sup>Written for commit 7e09bb867bd21893c70aa2f5c3ff07fdefecf344. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/goldener-data/goldener/pull/306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

