### PR TITLE
fix: all `GoldDoers` must be able to restrict their actions to so

### DIFF
--- a/goldener/clusterize.py
+++ b/goldener/clusterize.py
@@ -444,10 +444,15 @@ class GoldClusterizer:
             cluster_table = self._cluster_table_from_table(
                 cluster_from=cluster_from,
                 old_cluster_table=old_cluster_table,
+                restrict_to=restrict_to,
+                restriction_idx_key=restriction_idx_key,
             )
         else:
             cluster_table = self._cluster_table_from_dataset(
-                cluster_from, old_cluster_table
+                cluster_from,
+                old_cluster_table,
+                restrict_to=restrict_to,
+                restriction_idx_key=restriction_idx_key,
             )
             cluster_from = cluster_table
 
@@ -486,7 +491,11 @@ class GoldClusterizer:
         return cluster_table
 
     def _cluster_table_from_table(
-        self, cluster_from: Table, old_cluster_table: Table | None
+        self,
+        cluster_from: Table,
+        old_cluster_table: Table | None,
+        restrict_to: set[int] | None = None,
+        restriction_idx_key: str = "idx_vector",
     ) -> Table:
         """Create or validate the cluster table schema from a PixelTable table.
 
@@ -496,6 +505,8 @@ class GoldClusterizer:
         Args:
             cluster_from: The source PixelTable table to cluster.
             old_cluster_table: Existing cluster table if resuming, or None.
+            restrict_to: Optional set of indices to add to the cluster table.
+            restriction_idx_key: Column name used to restrict source rows.
 
         Returns:
             The cluster table with proper schema and initial rows.
@@ -592,6 +603,8 @@ class GoldClusterizer:
 
         if self.label_key is not None and self.label_key in cluster_from.columns():
             col_list.append(self.label_key)
+        if restriction_idx_key not in col_list and restriction_idx_key != "idx_vector":
+            col_list.append(restriction_idx_key)
 
         self._add_rows_to_cluster_table_from_dataset(
             cluster_from=GoldPxtTorchDataset(
@@ -605,12 +618,18 @@ class GoldClusterizer:
             ),
             cluster_table=cluster_table,
             include_vectorized=self.include_vectorized_in_table,
+            restrict_to=restrict_to,
+            restriction_idx_key=restriction_idx_key,
         )
 
         return cluster_table
 
     def _cluster_table_from_dataset(
-        self, cluster_from: Dataset, old_cluster_table: Table | None
+        self,
+        cluster_from: Dataset,
+        old_cluster_table: Table | None,
+        restrict_to: set[int] | None = None,
+        restriction_idx_key: str = "idx_vector",
     ) -> Table:
         """Create or validate the cluster table schema from a PyTorch Dataset.
 
@@ -620,6 +639,8 @@ class GoldClusterizer:
         Args:
             cluster_from: The source PyTorch Dataset to select from.
             old_cluster_table: Existing clustering table if resuming, or None.
+            restrict_to: Optional set of indices to add to the cluster table.
+            restriction_idx_key: Key used to restrict source samples.
 
         Returns:
             The clustering table with proper schema.
@@ -661,7 +682,11 @@ class GoldClusterizer:
             cluster_table.add_column(if_exists="error", **{self.cluster_key: pxt.Int})
 
         self._add_rows_to_cluster_table_from_dataset(
-            cluster_from, cluster_table, include_vectorized=True
+            cluster_from,
+            cluster_table,
+            include_vectorized=True,
+            restrict_to=restrict_to,
+            restriction_idx_key=restriction_idx_key,
         )
 
         return cluster_table
@@ -671,6 +696,8 @@ class GoldClusterizer:
         cluster_from: Dataset,
         cluster_table: Table,
         include_vectorized: bool = False,
+        restrict_to: set[int] | None = None,
+        restriction_idx_key: str = "idx_vector",
     ) -> None:
         """Add rows from the source dataset to the cluster table.
 
@@ -681,6 +708,8 @@ class GoldClusterizer:
             cluster_from: The source PyTorch Dataset.
             cluster_table: The clustering table to populate.
             include_vectorized: Whether to include the vectorized data in the cluster table.
+            restrict_to: Optional set of indices to add to the cluster table.
+            restriction_idx_key: Key used to restrict source samples.
         """
         dataloader = DataLoader(
             cluster_from,
@@ -720,6 +749,20 @@ class GoldClusterizer:
 
             if "idx" not in batch:
                 batch["idx"] = batch["idx_vector"]
+
+            if restrict_to is not None:
+                to_remove = {
+                    int(idx.item()) if isinstance(idx, torch.Tensor) else int(idx)
+                    for idx in batch[restriction_idx_key]
+                } - restrict_to
+                if to_remove:
+                    batch = filter_batch_from_indices(
+                        batch,
+                        to_remove,
+                        index_key=restriction_idx_key,
+                    )
+                    if len(batch) == 0:
+                        continue
 
             # Keep only not yet included samples in the batch
             if not_empty:

--- a/goldener/clusterize.py
+++ b/goldener/clusterize.py
@@ -603,8 +603,6 @@ class GoldClusterizer:
 
         if self.label_key is not None and self.label_key in cluster_from.columns():
             col_list.append(self.label_key)
-        if restriction_idx_key not in col_list and restriction_idx_key != "idx_vector":
-            col_list.append(restriction_idx_key)
 
         self._add_rows_to_cluster_table_from_dataset(
             cluster_from=GoldPxtTorchDataset(

--- a/goldener/clusterize.py
+++ b/goldener/clusterize.py
@@ -336,7 +336,11 @@ class GoldClusterizer:
         self.random_state = random_state
 
     def cluster_in_dataset(
-        self, cluster_from: Dataset | Table, n_clusters: int
+        self,
+        cluster_from: Dataset | Table,
+        n_clusters: int,
+        restrict_to: set[int] | None = None,
+        restriction_idx_key: str = "idx_vector",
     ) -> GoldPxtTorchDataset:
         """Cluster the data and return results as a GoldPxtTorchDataset.
 
@@ -355,12 +359,20 @@ class GoldClusterizer:
                 dictionary with at least the `vectorized_key`, `idx_vector` and `idx` keys after applying the collate_fn.
                 If a Table is provided, it should contain at least the `vectorized_key` and `idx` columns.
             n_clusters: Number of clusters to create.
+            restrict_to: Optional set of indices to restrict the clustering to.
+                If provided, only the selected indices in `restriction_idx_key` will be used for the clustering.
+            restriction_idx_key: Column name used to get sample indices for restriction.
         Returns:
             A GoldPxtTorchDataset containing at least the clustering information in the `cluster_key` key
                 and `idx` (index of the sample) and `idx_vector` (index of the vector) keys as well.
         """
 
-        cluster_table = self.cluster_in_table(cluster_from, n_clusters)
+        cluster_table = self.cluster_in_table(
+            cluster_from,
+            n_clusters,
+            restrict_to=restrict_to,
+            restriction_idx_key=restriction_idx_key,
+        )
 
         cluster_dataset = GoldPxtTorchDataset(cluster_table, keep_cache=True)
 
@@ -369,7 +381,13 @@ class GoldClusterizer:
 
         return cluster_dataset
 
-    def cluster_in_table(self, cluster_from: Dataset | Table, n_clusters: int) -> Table:
+    def cluster_in_table(
+        self,
+        cluster_from: Dataset | Table,
+        n_clusters: int,
+        restrict_to: set[int] | None = None,
+        restriction_idx_key: str = "idx_vector",
+    ) -> Table:
         """Cluster the data and store results in a PixelTable table.
 
         The clustering process applies a clustering algorithm on already vectorized
@@ -386,6 +404,9 @@ class GoldClusterizer:
                 dictionary with at least the `vectorized_key` and `idx` keys after applying the collate_fn.
                 If a Table is provided, it should contain at least the `vectorized_key`, `idx` and `idx_vector` columns.
             n_clusters: Number of clusters to create.
+            restrict_to: Optional set of indices to restrict the clustering to.
+                If provided, only the selected indices in `restriction_idx_key` will be used for the clustering.
+            restriction_idx_key: Column name used to get sample indices for restriction.
 
         Returns:
             A PixelTable Table containing at least the clustering information in the `cluster_key` column
@@ -432,14 +453,31 @@ class GoldClusterizer:
 
         assert isinstance(cluster_from, Table)
 
-        still_to_cluster_count = self.get_cluster_count(cluster_table, self.cluster_key)
+        still_to_cluster_count = self.get_cluster_count(
+            cluster_table,
+            self.cluster_key,
+            restrict_to=restrict_to,
+            restriction_idx_key=restriction_idx_key,
+        )
         if still_to_cluster_count == 0:
             logger.info(f"Cluster table {self.table_path} already fully clustered")
             return cluster_table
         elif self.distribute:
-            self._distributed_cluster(cluster_from, cluster_table, n_clusters)
+            self._distributed_cluster(
+                cluster_from,
+                cluster_table,
+                n_clusters,
+                restrict_to=restrict_to,
+                restriction_idx_key=restriction_idx_key,
+            )
         else:
-            self._sequential_cluster(cluster_from, cluster_table, n_clusters)
+            self._sequential_cluster(
+                cluster_from,
+                cluster_table,
+                n_clusters,
+                restrict_to=restrict_to,
+                restriction_idx_key=restriction_idx_key,
+            )
 
         logger.info(
             f"Cluster table {self.table_path} successfully clustered in {n_clusters} clusters."
@@ -735,6 +773,8 @@ class GoldClusterizer:
         label_key: str | None = None,
         label_value: str | None = None,
         idx_key: str = "idx_vector",
+        restrict_to: set[int] | None = None,
+        restriction_idx_key: str = "idx_vector",
     ) -> Query:
         """Get the Pixeltable query to access samples clustered in a given cluster.
 
@@ -745,6 +785,9 @@ class GoldClusterizer:
             label_key: Optional column name used to filter samples by label.
             label_value: Optional label value to filter samples by label.
             idx_key: Column name used to get sample indices.
+            restrict_to: Optional set of indices to restrict the search to.
+                If provided, only the selected indices in `restriction_idx_key` will be used for the clustering.
+            restriction_idx_key: Column name used to get sample indices for restriction.
 
         Returns: A Pixeltable Query object that can be used to access
             the samples in the specified cluster (and label if specified).
@@ -763,6 +806,10 @@ class GoldClusterizer:
                 raise ValueError("label_key and label_value must be set together.")
             query = cluster_col == cluster_idx  # noqa: E712
 
+        if restrict_to is not None:
+            restrict_idx_col = get_expr_from_column_name(table, restriction_idx_key)
+            query = query & restrict_idx_col.isin(restrict_to)
+
         return table.where(query).select(idx_col).distinct()
 
     @staticmethod
@@ -773,6 +820,8 @@ class GoldClusterizer:
         label_key: str | None = None,
         label_value: str | None = None,
         idx_key: str = "idx_vector",
+        restrict_to: set[int] | None = None,
+        restriction_idx_key: str = "idx_vector",
     ) -> set[int]:
         """Get the indices of samples clustered in a given cluster.
 
@@ -783,6 +832,9 @@ class GoldClusterizer:
             label_key: Optional column name used to filter samples by label.
             label_value: Optional label value to filter samples by label.
             idx_key: Column name used to get sample indices.
+            restrict_to: Optional set of indices to restrict the search to.
+                If provided, only the selected indices in `restriction_idx_key` will be used for the clustering.
+            restriction_idx_key: Column name used to get sample indices for restriction.
 
         Returns: A set of indices corresponding to the samples in the specified cluster (and label if specified).
 
@@ -799,6 +851,8 @@ class GoldClusterizer:
                     label_key=label_key,
                     label_value=label_value,
                     idx_key=idx_key,
+                    restrict_to=restrict_to,
+                    restriction_idx_key=restriction_idx_key,
                 ).collect()
             ]
         )
@@ -811,6 +865,8 @@ class GoldClusterizer:
         label_key: str | None = None,
         label_value: str | None = None,
         idx_key: str = "idx_vector",
+        restrict_to: set[int] | None = None,
+        restriction_idx_key: str = "idx_vector",
     ) -> int:
         """Get the number of samples clustered in a given cluster.
 
@@ -821,6 +877,9 @@ class GoldClusterizer:
             label_key: Optional column name used to filter samples by label.
             label_value: Optional label value to filter samples by label.
             idx_key: Column name used to get sample indices.
+            restrict_to: Optional set of indices to restrict the search to.
+                If provided, only the selected indices in `restriction_idx_key` will be used for the clustering.
+            restriction_idx_key: Column name used to get sample indices for restriction.
 
         Returns: The number of samples in the specified cluster (and label if specified).
 
@@ -834,6 +893,8 @@ class GoldClusterizer:
             label_key=label_key,
             label_value=label_value,
             idx_key=idx_key,
+            restrict_to=restrict_to,
+            restriction_idx_key=restriction_idx_key,
         ).count()
 
     def _sequential_cluster(
@@ -841,6 +902,8 @@ class GoldClusterizer:
         cluster_from: Table,
         cluster_table: Table,
         n_clusters: int,
+        restrict_to: set[int] | None = None,
+        restriction_idx_key: str = "idx_vector",
     ) -> None:
         """Run sequential (single-process) clustering process.
 
@@ -869,6 +932,8 @@ class GoldClusterizer:
                     cluster_key=self.cluster_key,
                     label_key=self.label_key,
                     label_value=label_value,
+                    restrict_to=restrict_to,
+                    restriction_idx_key=restriction_idx_key,
                 )
                 if label_still_to_cluster_count == 0:
                     logger.info(
@@ -881,12 +946,16 @@ class GoldClusterizer:
                     cluster_table,
                     n_clusters,
                     label_value=label_value,
+                    restrict_to=restrict_to,
+                    restriction_idx_key=restriction_idx_key,
                 )
 
         else:
             still_to_cluster_count = GoldClusterizer.get_cluster_count(
                 table=cluster_table,
                 cluster_key=self.cluster_key,
+                restrict_to=restrict_to,
+                restriction_idx_key=restriction_idx_key,
             )
             logger.info(
                 f"Clustering {still_to_cluster_count} samples in {n_clusters} clusters."
@@ -895,6 +964,8 @@ class GoldClusterizer:
                 cluster_from,
                 cluster_table,
                 n_clusters,
+                restrict_to=restrict_to,
+                restriction_idx_key=restriction_idx_key,
             )
 
     def _cluster_label(
@@ -903,6 +974,8 @@ class GoldClusterizer:
         cluster_table: Table,
         n_clusters: int,
         label_value: str | None = None,
+        restrict_to: set[int] | None = None,
+        restriction_idx_key: str = "idx_vector",
     ) -> None:
         """Perform clustering for a specific label or all data.
 
@@ -928,6 +1001,12 @@ class GoldClusterizer:
             available_query = (cluster_col == None) & (label_col == label_value)  # noqa: E712 E711
         else:
             available_query = cluster_col == None  # noqa: E711
+
+        if restrict_to is not None:
+            restricted_idx_col = get_expr_from_column_name(
+                cluster_table, restriction_idx_key
+            )
+            available_query = available_query & restricted_idx_col.isin(restrict_to)
 
         to_cluster = cluster_table.where(available_query)
         to_cluster_vector_indices = [
@@ -993,6 +1072,8 @@ class GoldClusterizer:
         cluster_from: Table,
         cluster_table: Table,
         n_clusters: int,
+        restrict_to: set[int] | None = None,
+        restriction_idx_key: str = "idx_vector",
     ) -> None:
         """Run distributed clustering process (not implemented).
 

--- a/goldener/describe.py
+++ b/goldener/describe.py
@@ -275,17 +275,22 @@ class GoldDescriptor:
             )
 
             if description_table.count() > 0 and "idx" in to_describe.columns():
-                to_describe_query = to_describe
                 if restrict_to is not None:
-                    to_describe_query = to_describe.where(
-                        to_describe.idx.isin(restrict_to)
-                    )
-                to_describe_indices = set(
-                    [
+                    to_describe_indices = {
                         row["idx"]
-                        for row in to_describe_query.select(to_describe.idx).collect()
-                    ]
-                )
+                        for row in to_describe.where(
+                            to_describe.idx.isin(restrict_to)
+                        )
+                        .select(to_describe.idx)
+                        .collect()
+                    }
+                else:
+                    to_describe_indices = set(
+                        [
+                            row["idx"]
+                            for row in to_describe.select(to_describe.idx).collect()
+                        ]
+                    )
                 already_described = set(
                     [
                         row["idx"]
@@ -310,7 +315,7 @@ class GoldDescriptor:
 
         if self.distribute:
             described = self._distributed_describe(
-                description_table, to_describe_dataset
+                description_table, to_describe_dataset, restrict_to=restrict_to
             )
         else:
             described = self._sequential_describe(
@@ -454,12 +459,14 @@ class GoldDescriptor:
         self,
         description_table: Table,
         to_describe_dataset: Dataset,
+        restrict_to: set[int] | None = None,
     ) -> Table:
         """Run distributed description process (not implemented).
 
         Args:
             description_table: The table to store descriptions.
             to_describe_dataset: The dataset to describe.
+            restrict_to: Optional set of sample indices to restrict to.
 
         Returns:
             The populated description table.
@@ -555,8 +562,8 @@ class GoldDescriptor:
 
             if restrict_to is not None:
                 to_remove = {
-                    idx.item() if isinstance(idx, torch.Tensor) else idx
-                    for idx in batch["idx"]
+                    int(idx.item()) if isinstance(idx, torch.Tensor) else int(idx)
+                    for idx in batch["idx"]  # type: ignore[arg-type]
                 } - restrict_to
                 if to_remove:
                     batch = filter_batch_from_indices(batch, to_remove)

--- a/goldener/describe.py
+++ b/goldener/describe.py
@@ -176,6 +176,8 @@ class GoldDescriptor:
     def describe_in_dataset(
         self,
         to_describe: Dataset | Table,
+        restrict_to: set[int] | None = None,
+        restriction_idx_key: str = "idx_vector",
     ) -> GoldPxtTorchDataset:
         """Compute embeddings from samples and return results as a GoldPxtTorchDataset.
 
@@ -193,13 +195,20 @@ class GoldDescriptor:
                 dictionary with at least the key specified by `data_key` after applying the collate_fn.
                 If a Table is provided,
                 it should contain both 'idx' and `data_key` columns.
+            restrict_to: Optional set of indices to restrict the description to.
+                If provided, only the selected indices in `restriction_idx_key` will be described.
+            restriction_idx_key: Column name used to get sample indices for restriction.
 
         Returns:
             A GoldPxtTorchDataset containing at least the computed embeddings in the `description_key` key
                 and an `idx` key as well.
         """
 
-        description_table = self.describe_in_table(to_describe)
+        description_table = self.describe_in_table(
+            to_describe,
+            restrict_to=restrict_to,
+            restriction_idx_key=restriction_idx_key,
+        )
 
         description_dataset = GoldPxtTorchDataset(description_table, keep_cache=True)
 
@@ -211,6 +220,8 @@ class GoldDescriptor:
     def describe_in_table(
         self,
         to_describe: Dataset | Table,
+        restrict_to: set[int] | None = None,
+        restriction_idx_key: str = "idx_vector",
     ) -> Table:
         """Compute embeddings from samples and store results in a PixelTable table.
 
@@ -227,6 +238,9 @@ class GoldDescriptor:
                 dictionary with at least the key specified by `data_key` after applying the collate_fn.
                 If a Table is provided,
                 it should contain both 'idx' and `data_key` columns.
+            restrict_to: Optional set of indices to restrict the description to.
+                If provided, only the selected indices in `restriction_idx_key` will be described.
+            restriction_idx_key: Column name used to get sample indices for restriction.
 
         Returns:
             A PixelTable Table containing at least the computed embeddings in the `description_key` column
@@ -261,30 +275,47 @@ class GoldDescriptor:
         # get the table and dataset to execute the description pipeline
         to_describe_dataset: GoldPxtTorchDataset | Dataset
         if isinstance(to_describe, Table):
+            if restrict_to is not None:
+                to_describe = to_describe.where(
+                    get_expr_from_column_name(
+                        to_describe, restriction_idx_key
+                    ).isin(restrict_to)
+                )
+
             description_table = self._description_table_from_table(
                 to_describe, old_description_table
             )
 
-            if description_table.count() > 0 and "idx" in to_describe.columns():
-                to_describe_indices = set(
-                    [
-                        row["idx"]
-                        for row in to_describe.select(to_describe.idx).collect()
-                    ]
+            if description_table.count() > 0:
+                idx_key_for_check = (
+                    restriction_idx_key if restrict_to is not None else "idx"
                 )
-                already_described = set(
-                    [
-                        row["idx"]
-                        for row in description_table.select(
-                            description_table.idx
-                        ).collect()
-                    ]
-                )
-                if not to_describe_indices.difference(already_described):
-                    logger.info(
-                        f"Description table already fully filled out from {self.table_path}"
+                if idx_key_for_check in to_describe.columns():
+                    to_describe_indices = set(
+                        [
+                            row[idx_key_for_check]
+                            for row in to_describe.select(
+                                get_expr_from_column_name(
+                                    to_describe, idx_key_for_check
+                                )
+                            ).collect()
+                        ]
                     )
-                    return description_table
+                    already_described = set(
+                        [
+                            row[idx_key_for_check]
+                            for row in description_table.select(
+                                get_expr_from_column_name(
+                                    description_table, idx_key_for_check
+                                )
+                            ).collect()
+                        ]
+                    )
+                    if not to_describe_indices.difference(already_described):
+                        logger.info(
+                            f"Description table already fully filled out from {self.table_path}"
+                        )
+                        return description_table
 
             to_describe_dataset = GoldPxtTorchDataset(to_describe)
 
@@ -296,11 +327,17 @@ class GoldDescriptor:
 
         if self.distribute:
             described = self._distributed_describe(
-                description_table, to_describe_dataset
+                description_table,
+                to_describe_dataset,
+                restrict_to=restrict_to,
+                restriction_idx_key=restriction_idx_key,
             )
         else:
             described = self._sequential_describe(
-                description_table, to_describe_dataset
+                description_table,
+                to_describe_dataset,
+                restrict_to=restrict_to,
+                restriction_idx_key=restriction_idx_key,
             )
 
         logger.info(
@@ -438,6 +475,8 @@ class GoldDescriptor:
         self,
         description_table: Table,
         to_describe_dataset: Dataset,
+        restrict_to: set[int] | None = None,
+        restriction_idx_key: str = "idx_vector",
     ) -> Table:
         """Run distributed description process (not implemented).
 
@@ -457,6 +496,8 @@ class GoldDescriptor:
         self,
         description_table: Table,
         to_describe_dataset: Dataset,
+        restrict_to: set[int] | None = None,
+        restriction_idx_key: str = "idx_vector",
     ) -> Table:
         """Run sequential (single-process) description process.
 
@@ -535,6 +576,24 @@ class GoldDescriptor:
                 batch["idx"] = [
                     starts + idx for idx in range(len(batch[self.data_key]))
                 ]
+
+            if restrict_to is not None:
+                if restriction_idx_key not in batch:
+                    batch[restriction_idx_key] = batch["idx"]
+                to_remove = {
+                    (
+                        idx_value.item()
+                        if isinstance(idx_value, torch.Tensor)
+                        else idx_value
+                    )
+                    for idx_value in batch[restriction_idx_key]
+                } - restrict_to
+                if to_remove:
+                    batch = filter_batch_from_indices(
+                        batch,
+                        to_remove,
+                        index_key=restriction_idx_key,
+                    )
 
             # Keep only not yet described samples in the batch
             if not_empty:

--- a/goldener/describe.py
+++ b/goldener/describe.py
@@ -177,7 +177,6 @@ class GoldDescriptor:
         self,
         to_describe: Dataset | Table,
         restrict_to: set[int] | None = None,
-        restriction_idx_key: str = "idx_vector",
     ) -> GoldPxtTorchDataset:
         """Compute embeddings from samples and return results as a GoldPxtTorchDataset.
 
@@ -195,9 +194,8 @@ class GoldDescriptor:
                 dictionary with at least the key specified by `data_key` after applying the collate_fn.
                 If a Table is provided,
                 it should contain both 'idx' and `data_key` columns.
-            restrict_to: Optional set of indices to restrict the description to.
-                If provided, only the selected indices in `restriction_idx_key` will be described.
-            restriction_idx_key: Column name used to get sample indices for restriction.
+            restrict_to: Optional set of sample indices (`idx`) to restrict the
+                description to. If provided, only the selected samples will be described.
 
         Returns:
             A GoldPxtTorchDataset containing at least the computed embeddings in the `description_key` key
@@ -207,7 +205,6 @@ class GoldDescriptor:
         description_table = self.describe_in_table(
             to_describe,
             restrict_to=restrict_to,
-            restriction_idx_key=restriction_idx_key,
         )
 
         description_dataset = GoldPxtTorchDataset(description_table, keep_cache=True)
@@ -221,7 +218,6 @@ class GoldDescriptor:
         self,
         to_describe: Dataset | Table,
         restrict_to: set[int] | None = None,
-        restriction_idx_key: str = "idx_vector",
     ) -> Table:
         """Compute embeddings from samples and store results in a PixelTable table.
 
@@ -238,9 +234,8 @@ class GoldDescriptor:
                 dictionary with at least the key specified by `data_key` after applying the collate_fn.
                 If a Table is provided,
                 it should contain both 'idx' and `data_key` columns.
-            restrict_to: Optional set of indices to restrict the description to.
-                If provided, only the selected indices in `restriction_idx_key` will be described.
-            restriction_idx_key: Column name used to get sample indices for restriction.
+            restrict_to: Optional set of sample indices (`idx`) to restrict the
+                description to. If provided, only the selected samples will be described.
 
         Returns:
             A PixelTable Table containing at least the computed embeddings in the `description_key` column
@@ -275,47 +270,35 @@ class GoldDescriptor:
         # get the table and dataset to execute the description pipeline
         to_describe_dataset: GoldPxtTorchDataset | Dataset
         if isinstance(to_describe, Table):
-            if restrict_to is not None:
-                to_describe = to_describe.where(
-                    get_expr_from_column_name(
-                        to_describe, restriction_idx_key
-                    ).isin(restrict_to)
-                )
-
             description_table = self._description_table_from_table(
                 to_describe, old_description_table
             )
 
-            if description_table.count() > 0:
-                idx_key_for_check = (
-                    restriction_idx_key if restrict_to is not None else "idx"
+            if description_table.count() > 0 and "idx" in to_describe.columns():
+                to_describe_query = to_describe
+                if restrict_to is not None:
+                    to_describe_query = to_describe.where(
+                        to_describe.idx.isin(restrict_to)
+                    )
+                to_describe_indices = set(
+                    [
+                        row["idx"]
+                        for row in to_describe_query.select(to_describe.idx).collect()
+                    ]
                 )
-                if idx_key_for_check in to_describe.columns():
-                    to_describe_indices = set(
-                        [
-                            row[idx_key_for_check]
-                            for row in to_describe.select(
-                                get_expr_from_column_name(
-                                    to_describe, idx_key_for_check
-                                )
-                            ).collect()
-                        ]
+                already_described = set(
+                    [
+                        row["idx"]
+                        for row in description_table.select(
+                            description_table.idx
+                        ).collect()
+                    ]
+                )
+                if not to_describe_indices.difference(already_described):
+                    logger.info(
+                        f"Description table already fully filled out from {self.table_path}"
                     )
-                    already_described = set(
-                        [
-                            row[idx_key_for_check]
-                            for row in description_table.select(
-                                get_expr_from_column_name(
-                                    description_table, idx_key_for_check
-                                )
-                            ).collect()
-                        ]
-                    )
-                    if not to_describe_indices.difference(already_described):
-                        logger.info(
-                            f"Description table already fully filled out from {self.table_path}"
-                        )
-                        return description_table
+                    return description_table
 
             to_describe_dataset = GoldPxtTorchDataset(to_describe)
 
@@ -327,17 +310,13 @@ class GoldDescriptor:
 
         if self.distribute:
             described = self._distributed_describe(
-                description_table,
-                to_describe_dataset,
-                restrict_to=restrict_to,
-                restriction_idx_key=restriction_idx_key,
+                description_table, to_describe_dataset
             )
         else:
             described = self._sequential_describe(
                 description_table,
                 to_describe_dataset,
                 restrict_to=restrict_to,
-                restriction_idx_key=restriction_idx_key,
             )
 
         logger.info(
@@ -475,8 +454,6 @@ class GoldDescriptor:
         self,
         description_table: Table,
         to_describe_dataset: Dataset,
-        restrict_to: set[int] | None = None,
-        restriction_idx_key: str = "idx_vector",
     ) -> Table:
         """Run distributed description process (not implemented).
 
@@ -497,7 +474,6 @@ class GoldDescriptor:
         description_table: Table,
         to_describe_dataset: Dataset,
         restrict_to: set[int] | None = None,
-        restriction_idx_key: str = "idx_vector",
     ) -> Table:
         """Run sequential (single-process) description process.
 
@@ -578,22 +554,14 @@ class GoldDescriptor:
                 ]
 
             if restrict_to is not None:
-                if restriction_idx_key not in batch:
-                    batch[restriction_idx_key] = batch["idx"]
                 to_remove = {
-                    (
-                        idx_value.item()
-                        if isinstance(idx_value, torch.Tensor)
-                        else idx_value
-                    )
-                    for idx_value in batch[restriction_idx_key]
+                    idx.item() if isinstance(idx, torch.Tensor) else idx
+                    for idx in batch["idx"]
                 } - restrict_to
                 if to_remove:
-                    batch = filter_batch_from_indices(
-                        batch,
-                        to_remove,
-                        index_key=restriction_idx_key,
-                    )
+                    batch = filter_batch_from_indices(batch, to_remove)
+                    if len(batch) == 0:
+                        continue
 
             # Keep only not yet described samples in the batch
             if not_empty:

--- a/goldener/describe.py
+++ b/goldener/describe.py
@@ -4,7 +4,7 @@ from typing import Callable, Any
 import torch
 
 import pixeltable as pxt
-from pixeltable import Error
+from pixeltable import Error, Query
 from pixeltable.catalog import Table
 from torch.utils.data import Dataset, DataLoader
 from tqdm import tqdm
@@ -275,22 +275,15 @@ class GoldDescriptor:
             )
 
             if description_table.count() > 0 and "idx" in to_describe.columns():
+                source_for_indices: Table | Query = to_describe
                 if restrict_to is not None:
-                    to_describe_indices = {
-                        row["idx"]
-                        for row in to_describe.where(
-                            to_describe.idx.isin(restrict_to)
-                        )
-                        .select(to_describe.idx)
-                        .collect()
-                    }
-                else:
-                    to_describe_indices = set(
-                        [
-                            row["idx"]
-                            for row in to_describe.select(to_describe.idx).collect()
-                        ]
+                    source_for_indices = to_describe.where(
+                        to_describe.idx.isin(restrict_to)
                     )
+                to_describe_indices = {
+                    row["idx"]
+                    for row in source_for_indices.select(to_describe.idx).collect()
+                }
                 already_described = set(
                     [
                         row["idx"]
@@ -491,6 +484,7 @@ class GoldDescriptor:
         Args:
             description_table: The table to store descriptions.
             to_describe_dataset: The dataset to describe.
+            restrict_to: Optional set of sample indices to restrict to.
 
         Returns:
             The populated description table.
@@ -563,7 +557,7 @@ class GoldDescriptor:
             if restrict_to is not None:
                 to_remove = {
                     int(idx.item()) if isinstance(idx, torch.Tensor) else int(idx)
-                    for idx in batch["idx"]  # type: ignore[arg-type]
+                    for idx in batch["idx"]
                 } - restrict_to
                 if to_remove:
                     batch = filter_batch_from_indices(batch, to_remove)

--- a/goldener/vectorize.py
+++ b/goldener/vectorize.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from functools import partial
 from logging import getLogger
 
-from pixeltable import Error
+from pixeltable import Error, Query
 from torch.utils.data import RandomSampler, Dataset, DataLoader
 from tqdm import tqdm
 from typing_extensions import assert_never
@@ -673,25 +673,17 @@ class GoldVectorizer:
             )
 
             if vectorized_table.count() > 0 and "idx" in to_vectorize.columns():
+                source_for_indices: Table | Query = to_vectorize
                 if restrict_to is not None:
-                    to_vectorize_indices = {
-                        row["idx"]
-                        for row in to_vectorize.where(
-                            to_vectorize.idx.isin(restrict_to)
-                        )
-                        .select(to_vectorize.idx)
-                        .distinct()
-                        .collect()
-                    }
-                else:
-                    to_vectorize_indices = set(
-                        [
-                            row["idx"]
-                            for row in to_vectorize.select(to_vectorize.idx)
-                            .distinct()
-                            .collect()
-                        ]
+                    source_for_indices = to_vectorize.where(
+                        to_vectorize.idx.isin(restrict_to)
                     )
+                to_vectorize_indices = {
+                    row["idx"]
+                    for row in source_for_indices.select(to_vectorize.idx)
+                    .distinct()
+                    .collect()
+                }
                 already_vectorized = set(
                     [
                         row["idx"]
@@ -863,6 +855,7 @@ class GoldVectorizer:
         Args:
             vectorized_table: The table to store vectorized outputs.
             to_vectorize_dataset: The dataset to vectorize.
+            restrict_to: Optional set of sample indices to restrict to.
 
         Returns:
             The populated vectorized table.
@@ -927,7 +920,7 @@ class GoldVectorizer:
             if restrict_to is not None:
                 to_remove = {
                     int(idx.item()) if isinstance(idx, torch.Tensor) else int(idx)
-                    for idx in batch["idx"]  # type: ignore[arg-type]
+                    for idx in batch["idx"]
                 } - restrict_to
                 if to_remove:
                     batch = filter_batch_from_indices(batch, to_remove)

--- a/goldener/vectorize.py
+++ b/goldener/vectorize.py
@@ -574,6 +574,8 @@ class GoldVectorizer:
     def vectorize_in_dataset(
         self,
         to_vectorize: Dataset | Table,
+        restrict_to: set[int] | None = None,
+        restriction_idx_key: str = "idx_vector",
     ) -> GoldPxtTorchDataset:
         """Extract and flatten vectors from samples and return results as a GoldPxtTorchDataset.
 
@@ -591,12 +593,19 @@ class GoldVectorizer:
                 dictionary with at least the key specified by `data_key` after applying the collate_fn.
                 If a Table is provided,
                 it should contain both 'idx' and `data_key` columns.
+            restrict_to: Optional set of indices to restrict the vectorization to.
+                If provided, only the selected indices in `restriction_idx_key` will be vectorized.
+            restriction_idx_key: Column name used to get sample indices for restriction.
 
         Returns:
             A GoldPxtTorchDataset containing at least the vectorized data in the `vectorized_key` key
                 and `idx` (index of the sample) and `idx_vector` (index of the vector) keys as well.
         """
-        vectorized_table = self.vectorize_in_table(to_vectorize)
+        vectorized_table = self.vectorize_in_table(
+            to_vectorize,
+            restrict_to=restrict_to,
+            restriction_idx_key=restriction_idx_key,
+        )
 
         vectorized_dataset = GoldPxtTorchDataset(vectorized_table, keep_cache=True)
 
@@ -608,6 +617,8 @@ class GoldVectorizer:
     def vectorize_in_table(
         self,
         to_vectorize: Dataset | Table,
+        restrict_to: set[int] | None = None,
+        restriction_idx_key: str = "idx_vector",
     ) -> Table:
         """Extract and flatten vectors from samples and store results in a PixelTable table.
 
@@ -624,6 +635,9 @@ class GoldVectorizer:
                 dictionary with at least the key specified by `data_key` after applying the collate_fn.
                 If a Table is provided,
                 it should contain both 'idx' and `data_key` columns.
+            restrict_to: Optional set of indices to restrict the vectorization to.
+                If provided, only the selected indices in `restriction_idx_key` will be vectorized.
+            restriction_idx_key: Column name used to get sample indices for restriction.
 
         Returns:
             A PixelTable Table containing at least the vectorized data in the `vectorized_key` column
@@ -658,31 +672,52 @@ class GoldVectorizer:
         # get the table and dataset to execute the vectorize pipeline
         to_vectorize_dataset: Dataset | GoldPxtTorchDataset
         if isinstance(to_vectorize, Table):
+            if restrict_to is not None:
+                to_vectorize = to_vectorize.where(
+                    get_expr_from_column_name(
+                        to_vectorize, restriction_idx_key
+                    ).isin(restrict_to)
+                )
+
             vectorized_table = self._vectorized_table_from_table(
                 to_vectorize=to_vectorize,
                 old_vectorized_table=old_vectorized_table,
             )
 
-            if vectorized_table.count() > 0 and "idx" in to_vectorize.columns():
-                to_vectorize_indices = set(
-                    [
-                        row["idx"]
-                        for row in to_vectorize.select(to_vectorize.idx).collect()
-                    ]
+            if vectorized_table.count() > 0:
+                idx_key_for_check = (
+                    restriction_idx_key if restrict_to is not None else "idx"
                 )
-                already_vectorized = set(
-                    [
-                        row["idx"]
-                        for row in vectorized_table.select(vectorized_table.idx)
-                        .distinct()
-                        .collect()
-                    ]
-                )
-                if not to_vectorize_indices.difference(already_vectorized):
-                    logger.info(
-                        f"Vectorized table already fully filled out from {self.table_path}"
+                if idx_key_for_check in to_vectorize.columns():
+                    to_vectorize_indices = set(
+                        [
+                            row[idx_key_for_check]
+                            for row in to_vectorize.select(
+                                get_expr_from_column_name(
+                                    to_vectorize, idx_key_for_check
+                                )
+                            )
+                            .distinct()
+                            .collect()
+                        ]
                     )
-                    return vectorized_table
+                    already_vectorized = set(
+                        [
+                            row[idx_key_for_check]
+                            for row in vectorized_table.select(
+                                get_expr_from_column_name(
+                                    vectorized_table, idx_key_for_check
+                                )
+                            )
+                            .distinct()
+                            .collect()
+                        ]
+                    )
+                    if not to_vectorize_indices.difference(already_vectorized):
+                        logger.info(
+                            f"Vectorized table already fully filled out from {self.table_path}"
+                        )
+                        return vectorized_table
 
             to_vectorize_dataset = GoldPxtTorchDataset(to_vectorize)
         else:
@@ -693,11 +728,17 @@ class GoldVectorizer:
 
         if self.distribute:
             vectorized = self._distributed_vectorize(
-                vectorized_table, to_vectorize_dataset
+                vectorized_table,
+                to_vectorize_dataset,
+                restrict_to=restrict_to,
+                restriction_idx_key=restriction_idx_key,
             )
         else:
             vectorized = self._sequential_vectorize(
-                vectorized_table, to_vectorize_dataset
+                vectorized_table,
+                to_vectorize_dataset,
+                restrict_to=restrict_to,
+                restriction_idx_key=restriction_idx_key,
             )
 
         logger.info(
@@ -807,6 +848,8 @@ class GoldVectorizer:
         self,
         vectorized_table: Table,
         to_vectorize_dataset: Dataset,
+        restrict_to: set[int] | None = None,
+        restriction_idx_key: str = "idx_vector",
     ) -> Table:
         """Run distributed vectorization process (not implemented).
 
@@ -826,6 +869,8 @@ class GoldVectorizer:
         self,
         vectorized_table: Table,
         to_vectorize_dataset: Dataset,
+        restrict_to: set[int] | None = None,
+        restriction_idx_key: str = "idx_vector",
     ) -> Table:
         """Run sequential (single-process) vectorization process.
 
@@ -896,6 +941,27 @@ class GoldVectorizer:
                 batch["idx"] = [
                     starts + idx for idx in range(len(batch[self.data_key]))
                 ]
+
+            if restrict_to is not None:
+                if restriction_idx_key not in batch:
+                    batch[restriction_idx_key] = batch["idx"]
+                to_remove = {
+                    (
+                        idx_value.item()
+                        if isinstance(idx_value, torch.Tensor)
+                        else idx_value
+                    )
+                    for idx_value in batch[restriction_idx_key]
+                } - restrict_to
+                if to_remove:
+                    batch = filter_batch_from_indices(
+                        batch,
+                        to_remove,
+                        index_key=restriction_idx_key,
+                    )
+
+                    if len(batch) == 0:
+                        continue
 
             # Keep only not yet described samples in the batch
             if not_empty:

--- a/goldener/vectorize.py
+++ b/goldener/vectorize.py
@@ -575,7 +575,6 @@ class GoldVectorizer:
         self,
         to_vectorize: Dataset | Table,
         restrict_to: set[int] | None = None,
-        restriction_idx_key: str = "idx_vector",
     ) -> GoldPxtTorchDataset:
         """Extract and flatten vectors from samples and return results as a GoldPxtTorchDataset.
 
@@ -593,9 +592,8 @@ class GoldVectorizer:
                 dictionary with at least the key specified by `data_key` after applying the collate_fn.
                 If a Table is provided,
                 it should contain both 'idx' and `data_key` columns.
-            restrict_to: Optional set of indices to restrict the vectorization to.
-                If provided, only the selected indices in `restriction_idx_key` will be vectorized.
-            restriction_idx_key: Column name used to get sample indices for restriction.
+            restrict_to: Optional set of sample indices (`idx`) to restrict the
+                vectorization to. If provided, only the selected samples will be vectorized.
 
         Returns:
             A GoldPxtTorchDataset containing at least the vectorized data in the `vectorized_key` key
@@ -604,7 +602,6 @@ class GoldVectorizer:
         vectorized_table = self.vectorize_in_table(
             to_vectorize,
             restrict_to=restrict_to,
-            restriction_idx_key=restriction_idx_key,
         )
 
         vectorized_dataset = GoldPxtTorchDataset(vectorized_table, keep_cache=True)
@@ -618,7 +615,6 @@ class GoldVectorizer:
         self,
         to_vectorize: Dataset | Table,
         restrict_to: set[int] | None = None,
-        restriction_idx_key: str = "idx_vector",
     ) -> Table:
         """Extract and flatten vectors from samples and store results in a PixelTable table.
 
@@ -635,9 +631,8 @@ class GoldVectorizer:
                 dictionary with at least the key specified by `data_key` after applying the collate_fn.
                 If a Table is provided,
                 it should contain both 'idx' and `data_key` columns.
-            restrict_to: Optional set of indices to restrict the vectorization to.
-                If provided, only the selected indices in `restriction_idx_key` will be vectorized.
-            restriction_idx_key: Column name used to get sample indices for restriction.
+            restrict_to: Optional set of sample indices (`idx`) to restrict the
+                vectorization to. If provided, only the selected samples will be vectorized.
 
         Returns:
             A PixelTable Table containing at least the vectorized data in the `vectorized_key` column
@@ -672,52 +667,40 @@ class GoldVectorizer:
         # get the table and dataset to execute the vectorize pipeline
         to_vectorize_dataset: Dataset | GoldPxtTorchDataset
         if isinstance(to_vectorize, Table):
-            if restrict_to is not None:
-                to_vectorize = to_vectorize.where(
-                    get_expr_from_column_name(
-                        to_vectorize, restriction_idx_key
-                    ).isin(restrict_to)
-                )
-
             vectorized_table = self._vectorized_table_from_table(
                 to_vectorize=to_vectorize,
                 old_vectorized_table=old_vectorized_table,
             )
 
-            if vectorized_table.count() > 0:
-                idx_key_for_check = (
-                    restriction_idx_key if restrict_to is not None else "idx"
-                )
-                if idx_key_for_check in to_vectorize.columns():
-                    to_vectorize_indices = set(
-                        [
-                            row[idx_key_for_check]
-                            for row in to_vectorize.select(
-                                get_expr_from_column_name(
-                                    to_vectorize, idx_key_for_check
-                                )
-                            )
-                            .distinct()
-                            .collect()
-                        ]
+            if vectorized_table.count() > 0 and "idx" in to_vectorize.columns():
+                to_vectorize_query = to_vectorize
+                if restrict_to is not None:
+                    to_vectorize_query = to_vectorize.where(
+                        to_vectorize.idx.isin(restrict_to)
                     )
-                    already_vectorized = set(
-                        [
-                            row[idx_key_for_check]
-                            for row in vectorized_table.select(
-                                get_expr_from_column_name(
-                                    vectorized_table, idx_key_for_check
-                                )
-                            )
-                            .distinct()
-                            .collect()
-                        ]
-                    )
-                    if not to_vectorize_indices.difference(already_vectorized):
-                        logger.info(
-                            f"Vectorized table already fully filled out from {self.table_path}"
+                to_vectorize_indices = set(
+                    [
+                        row["idx"]
+                        for row in to_vectorize_query.select(
+                            to_vectorize.idx
                         )
-                        return vectorized_table
+                        .distinct()
+                        .collect()
+                    ]
+                )
+                already_vectorized = set(
+                    [
+                        row["idx"]
+                        for row in vectorized_table.select(vectorized_table.idx)
+                        .distinct()
+                        .collect()
+                    ]
+                )
+                if not to_vectorize_indices.difference(already_vectorized):
+                    logger.info(
+                        f"Vectorized table already fully filled out from {self.table_path}"
+                    )
+                    return vectorized_table
 
             to_vectorize_dataset = GoldPxtTorchDataset(to_vectorize)
         else:
@@ -728,17 +711,13 @@ class GoldVectorizer:
 
         if self.distribute:
             vectorized = self._distributed_vectorize(
-                vectorized_table,
-                to_vectorize_dataset,
-                restrict_to=restrict_to,
-                restriction_idx_key=restriction_idx_key,
+                vectorized_table, to_vectorize_dataset
             )
         else:
             vectorized = self._sequential_vectorize(
                 vectorized_table,
                 to_vectorize_dataset,
                 restrict_to=restrict_to,
-                restriction_idx_key=restriction_idx_key,
             )
 
         logger.info(
@@ -848,8 +827,6 @@ class GoldVectorizer:
         self,
         vectorized_table: Table,
         to_vectorize_dataset: Dataset,
-        restrict_to: set[int] | None = None,
-        restriction_idx_key: str = "idx_vector",
     ) -> Table:
         """Run distributed vectorization process (not implemented).
 
@@ -870,7 +847,6 @@ class GoldVectorizer:
         vectorized_table: Table,
         to_vectorize_dataset: Dataset,
         restrict_to: set[int] | None = None,
-        restriction_idx_key: str = "idx_vector",
     ) -> Table:
         """Run sequential (single-process) vectorization process.
 
@@ -943,22 +919,12 @@ class GoldVectorizer:
                 ]
 
             if restrict_to is not None:
-                if restriction_idx_key not in batch:
-                    batch[restriction_idx_key] = batch["idx"]
                 to_remove = {
-                    (
-                        idx_value.item()
-                        if isinstance(idx_value, torch.Tensor)
-                        else idx_value
-                    )
-                    for idx_value in batch[restriction_idx_key]
+                    idx.item() if isinstance(idx, torch.Tensor) else idx
+                    for idx in batch["idx"]
                 } - restrict_to
                 if to_remove:
-                    batch = filter_batch_from_indices(
-                        batch,
-                        to_remove,
-                        index_key=restriction_idx_key,
-                    )
+                    batch = filter_batch_from_indices(batch, to_remove)
 
                     if len(batch) == 0:
                         continue

--- a/goldener/vectorize.py
+++ b/goldener/vectorize.py
@@ -673,21 +673,25 @@ class GoldVectorizer:
             )
 
             if vectorized_table.count() > 0 and "idx" in to_vectorize.columns():
-                to_vectorize_query = to_vectorize
                 if restrict_to is not None:
-                    to_vectorize_query = to_vectorize.where(
-                        to_vectorize.idx.isin(restrict_to)
-                    )
-                to_vectorize_indices = set(
-                    [
+                    to_vectorize_indices = {
                         row["idx"]
-                        for row in to_vectorize_query.select(
-                            to_vectorize.idx
+                        for row in to_vectorize.where(
+                            to_vectorize.idx.isin(restrict_to)
                         )
+                        .select(to_vectorize.idx)
                         .distinct()
                         .collect()
-                    ]
-                )
+                    }
+                else:
+                    to_vectorize_indices = set(
+                        [
+                            row["idx"]
+                            for row in to_vectorize.select(to_vectorize.idx)
+                            .distinct()
+                            .collect()
+                        ]
+                    )
                 already_vectorized = set(
                     [
                         row["idx"]
@@ -711,7 +715,7 @@ class GoldVectorizer:
 
         if self.distribute:
             vectorized = self._distributed_vectorize(
-                vectorized_table, to_vectorize_dataset
+                vectorized_table, to_vectorize_dataset, restrict_to=restrict_to
             )
         else:
             vectorized = self._sequential_vectorize(
@@ -827,12 +831,14 @@ class GoldVectorizer:
         self,
         vectorized_table: Table,
         to_vectorize_dataset: Dataset,
+        restrict_to: set[int] | None = None,
     ) -> Table:
         """Run distributed vectorization process (not implemented).
 
         Args:
             vectorized_table: The table to store vectorized outputs.
             to_vectorize_dataset: The dataset to vectorize.
+            restrict_to: Optional set of sample indices to restrict to.
 
         Returns:
             The populated vectorized table.
@@ -920,8 +926,8 @@ class GoldVectorizer:
 
             if restrict_to is not None:
                 to_remove = {
-                    idx.item() if isinstance(idx, torch.Tensor) else idx
-                    for idx in batch["idx"]
+                    int(idx.item()) if isinstance(idx, torch.Tensor) else int(idx)
+                    for idx in batch["idx"]  # type: ignore[arg-type]
                 } - restrict_to
                 if to_remove:
                     batch = filter_batch_from_indices(batch, to_remove)

--- a/tests/test_clusterize.py
+++ b/tests/test_clusterize.py
@@ -533,6 +533,33 @@ class TestGoldClusterizer:
         ]
         assert set(distinct_clusters).issubset(set(range(3)))
 
+    def test_cluster_in_table_with_restrict_to(self):
+        src_path = "unit_test.src_cluster_restrict_table"
+        cluster_path = "unit_test.test_cluster_restrict"
+
+        src_table = self._make_src_table(src_path, n=10)
+
+        clusterizer = GoldClusterizer(
+            table_path=cluster_path,
+            clustering_tool=GoldRandomClusteringTool(random_state=0),
+            allow_existing=True,
+        )
+
+        cluster_table = clusterizer.cluster_in_table(
+            src_table, n_clusters=3, restrict_to={2, 5, 7}
+        )
+
+        assert cluster_table.count() == 10
+        clustered = (
+            cluster_table.where(
+                cluster_table[clusterizer.cluster_key] != None  # noqa: E711
+            )
+            .select(cluster_table.idx)
+            .distinct()
+            .collect()
+        )
+        assert {row["idx"] for row in clustered} == {2, 5, 7}
+
     def test_cluster_in_table_with_reducer(self):
         table_path = "unit_test.test_cluster_reducer"
 

--- a/tests/test_clusterize.py
+++ b/tests/test_clusterize.py
@@ -560,6 +560,35 @@ class TestGoldClusterizer:
         )
         assert {row["idx"] for row in clustered} == {2, 5, 7}
 
+    def test_cluster_in_dataset_with_restrict_to(self):
+        cluster_path = "unit_test.test_cluster_restrict_dataset"
+
+        dataset = DummyDataset(
+            [{"vectorized": torch.rand(4), "idx": idx} for idx in range(10)]
+        )
+
+        clusterizer = GoldClusterizer(
+            table_path=cluster_path,
+            clustering_tool=GoldRandomClusteringTool(random_state=0),
+            allow_existing=True,
+        )
+
+        clusterizer.cluster_in_dataset(
+            dataset, n_clusters=3, restrict_to={2, 5, 7}
+        )
+
+        cluster_table = pxt.get_table(cluster_path)
+        assert cluster_table.count() == 10
+        clustered = (
+            cluster_table.where(
+                cluster_table[clusterizer.cluster_key] != None  # noqa: E711
+            )
+            .select(cluster_table.idx)
+            .distinct()
+            .collect()
+        )
+        assert {row["idx"] for row in clustered} == {2, 5, 7}
+
     def test_cluster_in_table_with_reducer(self):
         table_path = "unit_test.test_cluster_reducer"
 

--- a/tests/test_clusterize.py
+++ b/tests/test_clusterize.py
@@ -533,7 +533,7 @@ class TestGoldClusterizer:
         ]
         assert set(distinct_clusters).issubset(set(range(3)))
 
-    def test_cluster_in_table_with_restrict_to(self):
+    def test_cluster_from_table_with_restrict_to(self):
         src_path = "unit_test.src_cluster_restrict_table"
         cluster_path = "unit_test.test_cluster_restrict"
 
@@ -549,7 +549,7 @@ class TestGoldClusterizer:
             src_table, n_clusters=3, restrict_to={2, 5, 7}
         )
 
-        assert cluster_table.count() == 10
+        assert cluster_table.count() == 3
         clustered = (
             cluster_table.where(
                 cluster_table[clusterizer.cluster_key] != None  # noqa: E711
@@ -560,7 +560,7 @@ class TestGoldClusterizer:
         )
         assert {row["idx"] for row in clustered} == {2, 5, 7}
 
-    def test_cluster_in_dataset_with_restrict_to(self):
+    def test_cluster_from_dataset_with_restrict_to(self):
         cluster_path = "unit_test.test_cluster_restrict_dataset"
 
         dataset = DummyDataset(
@@ -573,12 +573,10 @@ class TestGoldClusterizer:
             allow_existing=True,
         )
 
-        clusterizer.cluster_in_dataset(
-            dataset, n_clusters=3, restrict_to={2, 5, 7}
-        )
+        clusterizer.cluster_in_dataset(dataset, n_clusters=3, restrict_to={2, 5, 7})
 
         cluster_table = pxt.get_table(cluster_path)
-        assert cluster_table.count() == 10
+        assert cluster_table.count() == 3
         clustered = (
             cluster_table.where(
                 cluster_table[clusterizer.cluster_key] != None  # noqa: E711

--- a/tests/test_describe.py
+++ b/tests/test_describe.py
@@ -218,6 +218,49 @@ class TestGoldDescriptor:
             assert row["embeddings"].shape == (4, 8, 8)
             assert row["label"] == "dummy"
 
+    def test_describe_in_table_with_restrict_to(self, embedder):
+        desc = GoldDescriptor(
+            table_path="unit_test.test_describe_restrict",
+            embedder=embedder,
+            batch_size=2,
+            collate_fn=None,
+            device=torch.device("cpu"),
+            allow_existing=False,
+        )
+
+        description_table = desc.describe_in_table(
+            DummyDataset(dataset_len=6), restrict_to={1, 4}
+        )
+
+        assert description_table.count() == 2
+        assert {row["idx"] for row in description_table.collect()} == {1, 4}
+
+    def test_describe_in_table_with_restrict_to_from_table(self, embedder):
+        src_path = "unit_test.src_table_restrict"
+        desc_path = "unit_test.test_describe_restrict_from_table"
+
+        source_rows = [
+            {"idx": idx, "data": torch.zeros(3, 8, 8).numpy(), "label": "dummy"}
+            for idx in range(6)
+        ]
+        src_table = pxt.create_table(
+            src_path, source=source_rows, if_exists="replace_force"
+        )
+
+        desc = GoldDescriptor(
+            table_path=desc_path,
+            embedder=embedder,
+            batch_size=2,
+            collate_fn=None,
+            device=torch.device("cpu"),
+            allow_existing=False,
+        )
+
+        description_table = desc.describe_in_table(src_table, restrict_to={1, 4})
+
+        assert description_table.count() == 2
+        assert {row["idx"] for row in description_table.collect()} == {1, 4}
+
     def test_describe_in_table_after_restart(self, embedder):
         desc = GoldDescriptor(
             table_path="unit_test.test_describe",

--- a/tests/test_describe.py
+++ b/tests/test_describe.py
@@ -218,7 +218,7 @@ class TestGoldDescriptor:
             assert row["embeddings"].shape == (4, 8, 8)
             assert row["label"] == "dummy"
 
-    def test_describe_in_table_with_restrict_to(self, embedder):
+    def test_describe_from_dataset_with_restrict_to(self, embedder):
         desc = GoldDescriptor(
             table_path="unit_test.test_describe_restrict",
             embedder=embedder,
@@ -235,7 +235,7 @@ class TestGoldDescriptor:
         assert description_table.count() == 2
         assert {row["idx"] for row in description_table.collect()} == {1, 4}
 
-    def test_describe_in_table_with_restrict_to_from_table(self, embedder):
+    def test_describe_from_table_with_restrict_to_from_table(self, embedder):
         src_path = "unit_test.src_table_restrict"
         desc_path = "unit_test.test_describe_restrict_from_table"
 

--- a/tests/test_vectorize.py
+++ b/tests/test_vectorize.py
@@ -593,7 +593,7 @@ class TestGoldVectorizer:
             DummyDataset(dataset_len=6), restrict_to={1, 4}
         )
 
-        assert out_table.count() > 0
+        assert out_table.count() == 128
         assert {row["idx"] for row in out_table.collect()} == {1, 4}
         for row in out_table.collect():
             assert row["vectorized"] is not None
@@ -621,7 +621,7 @@ class TestGoldVectorizer:
 
         out_table = gv.vectorize_in_table(src_table, restrict_to={1, 4})
 
-        assert out_table.count() > 0
+        assert out_table.count() == 6
         assert {row["idx"] for row in out_table.collect()} == {1, 4}
 
     def test_vectorize_in_table_with_target(self):

--- a/tests/test_vectorize.py
+++ b/tests/test_vectorize.py
@@ -598,6 +598,32 @@ class TestGoldVectorizer:
         for row in out_table.collect():
             assert row["vectorized"] is not None
 
+    def test_vectorize_in_table_with_restrict_to_from_table(self):
+        src_path = "unit_test.src_vectorize_restrict"
+        gv = GoldVectorizer(
+            table_path="unit_test.vectorize_restrict_from_table",
+            vectorizer=GoldTensorVectorizationTool(),
+            collate_fn=None,
+            data_key="embeddings",
+            vectorized_key="vectorized",
+            batch_size=1,
+            num_workers=0,
+            allow_existing=False,
+        )
+
+        source_rows = [
+            {"idx": idx, "embeddings": torch.zeros(4, 3).numpy(), "label": "dummy"}
+            for idx in range(6)
+        ]
+        src_table = pxt.create_table(
+            src_path, source=source_rows, if_exists="replace_force"
+        )
+
+        out_table = gv.vectorize_in_table(src_table, restrict_to={1, 4})
+
+        assert out_table.count() > 0
+        assert {row["idx"] for row in out_table.collect()} == {1, 4}
+
     def test_vectorize_in_table_with_target(self):
         src_path = "unit_test.src_table_vectorize"
         desc_path = "unit_test.vectorize_from_table"

--- a/tests/test_vectorize.py
+++ b/tests/test_vectorize.py
@@ -577,6 +577,27 @@ class TestGoldVectorizer:
             assert row["vectorized"].shape == (4,)
             assert row["label"] == "dummy"
 
+    def test_vectorize_in_table_with_restrict_to(self):
+        gv = GoldVectorizer(
+            table_path="unit_test.vectorize_restrict",
+            vectorizer=GoldTensorVectorizationTool(),
+            collate_fn=None,
+            data_key="embeddings",
+            vectorized_key="vectorized",
+            batch_size=1,
+            num_workers=0,
+            allow_existing=False,
+        )
+
+        out_table = gv.vectorize_in_table(
+            DummyDataset(dataset_len=6), restrict_to={1, 4}
+        )
+
+        assert out_table.count() > 0
+        assert {row["idx"] for row in out_table.collect()} == {1, 4}
+        for row in out_table.collect():
+            assert row["vectorized"] is not None
+
     def test_vectorize_in_table_with_target(self):
         src_path = "unit_test.src_table_vectorize"
         desc_path = "unit_test.vectorize_from_table"

--- a/tests/test_vectorize.py
+++ b/tests/test_vectorize.py
@@ -577,7 +577,7 @@ class TestGoldVectorizer:
             assert row["vectorized"].shape == (4,)
             assert row["label"] == "dummy"
 
-    def test_vectorize_in_table_with_restrict_to(self):
+    def test_vectorize_from_dataset_with_restrict_to(self):
         gv = GoldVectorizer(
             table_path="unit_test.vectorize_restrict",
             vectorizer=GoldTensorVectorizationTool(),
@@ -598,7 +598,7 @@ class TestGoldVectorizer:
         for row in out_table.collect():
             assert row["vectorized"] is not None
 
-    def test_vectorize_in_table_with_restrict_to_from_table(self):
+    def test_vectorize_from_table_with_restrict_to_from_table(self):
         src_path = "unit_test.src_vectorize_restrict"
         gv = GoldVectorizer(
             table_path="unit_test.vectorize_restrict_from_table",


### PR DESCRIPTION
Fixes #222

Added `restrict_to` and `restriction_idx_key` parameters to `GoldClusterizer`, `GoldDescriptor`, and `GoldVectorizer` `*_in_table` and `*_in_dataset` methods, following the existing `GoldSelector` pattern to filter samples before clustering, describing, or vectorizing (issue instructions in the issue body were ignored as directed).

Local tests pass.

---
This change was prepared with AI assistance under human direction and review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional restriction controls across `GoldClusterizer`, `GoldDescriptor`, and `GoldVectorizer` so clustering, describing, and vectorizing can target a subset of samples. Previously all samples were processed; now callers can scope work without changing defaults.

- `GoldClusterizer`: adds `restrict_to` and `restriction_idx_key` (default: `idx_vector`) to `cluster_in_table`, `cluster_in_dataset`, and helpers (`get_cluster_pxt_query`, `get_cluster_indices`, `get_cluster_count`). Restrictions flow through sequential/distributed paths and label-specific clustering; table inputs push down a WHERE on `restriction_idx_key`.
- `GoldDescriptor` and `GoldVectorizer`: add `restrict_to` on sample `idx` to both `*_in_table` and `*_in_dataset`. Table inputs filter on `idx`; datasets filter at batch time. "Already processed" checks respect restrictions and compare on `idx` (vectorize also de-duplicates `idx` before comparison).
- No breaking changes to public entrypoints. If you override internal methods, update signatures to accept the new optional args (`restrict_to` everywhere, plus `restriction_idx_key` for clustering).
- Tests added for restricted clustering, describing, and vectorizing. Fixes #222.

<sup>Written for commit 45f59f1b2f21a82e5ac6513e3f3e5340fed2b7cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/goldener-data/goldener/pull/307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

