### PR TITLE
docs: add return type annotations to GoldClusterizedBatchSampler methods

### DIFF
--- a/goldener/organize.py
+++ b/goldener/organize.py
@@ -103,7 +103,7 @@ class GoldClusterizedBatchSampler(Sampler):
         shuffle: bool = True,
         generator: Generator | None = None,
         strategy: ExhaustedClusterStrategy = ExhaustedClusterStrategy.RESTART,
-    ):
+    ) -> None:
         """Initialize the batch sampler based on clustering results.
 
         Args:
@@ -177,7 +177,7 @@ class GoldClusterizedBatchSampler(Sampler):
                 "All the clusters are required to have the same size when `force_same_size=True`"
             )
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[list[int]]:
         if self.generator is None:
             seed = int(torch.empty((), dtype=torch.int64).random_().item())
             generator = torch.Generator()


### PR DESCRIPTION
## Summary

Adds the missing return type annotations flagged by mypy in `goldener/organize.py` (annotation-unchecked notes at lines 189-197):

- `GoldClusterizedBatchSampler.__init__` → `-> None`
- `GoldClusterizedBatchSampler.__iter__` → `-> Iterator[list[int]]`

This lets mypy type-check the method bodies instead of skipping them as untyped functions.

## Changes

- `goldener/organize.py`: two return annotations added; no behavior change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds return type annotations to `GoldClusterizedBatchSampler.__init__` and `__iter__` in `goldener/organize.py` so mypy type-checks the method bodies instead of skipping them as untyped functions. No behavior change.

- `__init__` now declares `-> None`.
- `__iter__` now declares `-> Iterator[list[int]]`, with `Iterator` imported from `typing`.

<sup>Written for commit 0b012902513c4d3d83b53748a3e2d38a09ff2c87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/goldener-data/goldener/pull/312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

