### PR TITLE
Add missing return type annotations in organize.py

### DIFF
--- a/goldener/organize.py
+++ b/goldener/organize.py
@@ -1,6 +1,7 @@
 from enum import Enum
 from logging import getLogger
 from typing import Sequence
+from typing import Iterator
 
 import torch
 from torch.utils.data import Dataset, Sampler, Subset
@@ -103,7 +104,7 @@ class GoldClusterizedBatchSampler(Sampler):
         shuffle: bool = True,
         generator: Generator | None = None,
         strategy: ExhaustedClusterStrategy = ExhaustedClusterStrategy.RESTART,
-    ):
+    ) -> None:
         """Initialize the batch sampler based on clustering results.
 
         Args:
@@ -177,7 +178,7 @@ class GoldClusterizedBatchSampler(Sampler):
                 "All the clusters are required to have the same size when `force_same_size=True`"
             )
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[list[int]]:
         if self.generator is None:
             seed = int(torch.empty((), dtype=torch.int64).random_().item())
             generator = torch.Generator()
@@ -209,7 +210,7 @@ class GoldClusterizedBatchSampler(Sampler):
         def draw_samples(
             to_sample_from: list[int],
             to_sample_size: int,
-        ):
+        ) -> list[int]:
             """Closure drawing the next samples for the batch (one per remaining clusters).
 
             It defines from which cluster the samples are drawn. The samples are drawn from the pointer status of
@@ -300,7 +301,7 @@ class GoldClusterizedBatchSampler(Sampler):
         while len(exhausted_once) < len(cluster_pools):
             if self._batch_size > len(remaining_clusters):
                 # requires to select multiple times from remaining clusters
-                batch = []
+                batch: list[int] = []
                 while len(batch) < self._batch_size and len(remaining_clusters) > 0:
                     still_to_get = self._batch_size - len(batch)
                     batch.extend(


### PR DESCRIPTION
## Summary
Adds the missing return type annotations in `organize.py` as requested in #311.

- `GoldClusterizedBatchSampler.__init__` → `-> None`
- `GoldClusterizedBatchSampler.__iter__` → `-> Iterator[list[int]]`
- inner closure `draw_samples` → `-> list[int]`
- added explicit `batch: list[int] = []` annotation where needed

## Motivation
Mypy was previously skipping body checks for these functions and emitting
`annotation-unchecked` notes since they were untyped. Adding explicit return
types allows mypy to fully check these function bodies.

## Testing
- Ran `mypy goldener/organize.py` — no errors
- Ran `ruff check` / `ruff format --check` — clean
- Ran existing test suite (`pytest`) — all passing

Closes #311

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds missing return type annotations in `goldener/organize.py` so mypy fully checks these functions and no longer emits `annotation-unchecked` notes.

- Adds `-> None` to `GoldClusterizedBatchSampler.__init__`, `-> Iterator[list[int]]` to `__iter__`, and `-> list[int]` to the `draw_samples` closure.
- Adds an explicit `batch: list[int]` annotation.
- Closes #311; `mypy`, `ruff`, and `pytest` all pass.

<sup>Written for commit 2b457e3c3bb957c7a3b24ff82658a13bbf57844f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/goldener-data/goldener/pull/313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

