### PR TITLE
Add missing type annotations to organize.py

### DIFF
--- a/goldener/organize.py
+++ b/goldener/organize.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from logging import getLogger
-from typing import Sequence
+from typing import Iterator, Sequence
 
 import torch
 from torch.utils.data import Dataset, Sampler, Subset
@@ -103,7 +103,7 @@ class GoldClusterizedBatchSampler(Sampler):
         shuffle: bool = True,
         generator: Generator | None = None,
         strategy: ExhaustedClusterStrategy = ExhaustedClusterStrategy.RESTART,
-    ):
+    ) -> None:
         """Initialize the batch sampler based on clustering results.
 
         Args:
@@ -177,7 +177,7 @@ class GoldClusterizedBatchSampler(Sampler):
                 "All the clusters are required to have the same size when `force_same_size=True`"
             )
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[list[int]]:
         if self.generator is None:
             seed = int(torch.empty((), dtype=torch.int64).random_().item())
             generator = torch.Generator()
@@ -209,7 +209,7 @@ class GoldClusterizedBatchSampler(Sampler):
         def draw_samples(
             to_sample_from: list[int],
             to_sample_size: int,
-        ):
+        ) -> list[int]:
             """Closure drawing the next samples for the batch (one per remaining clusters).
 
             It defines from which cluster the samples are drawn. The samples are drawn from the pointer status of


### PR DESCRIPTION
## Changes
- Add return type annotation to GoldClusterizedBatchSampler.__init__
- Add return type annotation to GoldClusterizedBatchSampler.__iter__
- Add return type annotation to draw_samples
- Import Iterator from typing

Closes #311

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds missing type annotations to `goldener/organize.py` so the module is fully typed and satisfies issue #311.

- Annotates `GoldClusterizedBatchSampler.__init__`, `GoldClusterizedBatchSampler.__iter__`, and `draw_samples` with return types.
- Imports `Iterator` from `typing` for the new annotation.

<sup>Written for commit e2b70c6fdcb0d94dab02e6012869ecf49c18e1f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/goldener-data/goldener/pull/314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

