### PR TITLE
Generalize sequence-preserving PyTorch collation

### DIFF
--- a/goldener/clusterize.py
+++ b/goldener/clusterize.py
@@ -21,10 +21,12 @@ from goldener.pxt_utils import (
     make_batch_ready_for_table,
     check_pxt_table_has_primary_key,
     get_sample_row_from_idx,
-    pxt_torch_dataset_collate_fn,
 )
 from goldener.reduce import GoldReductionTool, GoldReductionToolWithFit
-from goldener.torch_utils import get_dataset_sample_dict
+from goldener.torch_utils import (
+    collate_keeping_sequences_as_sequences,
+    get_dataset_sample_dict,
+)
 from goldener.utils import (
     filter_batch_from_indices,
 )
@@ -235,7 +237,7 @@ class GoldClusterizer:
         chunk: Optional chunk size for processing data in chunks to reduce memory consumption.
         collate_fn: Optional function to collate dataset samples into batches composed of
             dictionaries with at least the key specified by `vectorized_key` returning a PyTorch Tensor.
-            If None, `pxt_torch_dataset_collate_fn` is used, which preserves list-valued
+            If None, `collate_keeping_sequences_as_sequences` is used, which preserves sequence-valued
             fields as one list per sample.
         vectorized_key: Key in the batch dictionary that contains the vectorized data for the clustering. Default is "vectorized".
         include_vectorized_in_table: Whether to keep the vectorized data in the cluster table.
@@ -290,7 +292,7 @@ class GoldClusterizer:
             chunk: Optional chunk size for processing data in chunks to reduce memory consumption.
             collate_fn: Optional function to collate dataset samples into batches composed of
                 dictionaries with at least the key specified by `vectorized_key` returning a PyTorch Tensor.
-                If None, `pxt_torch_dataset_collate_fn` is used, which preserves list-valued
+                If None, `collate_keeping_sequences_as_sequences` is used, which preserves sequence-valued
                 fields as one list per sample.
             vectorized_key: Key in the batch dictionary that contains the vectorized data for the clustering. Default is "vectorized".
             include_vectorized_in_table: Whether to keep the vectorized data in the cluster table. Defaults to False.
@@ -320,7 +322,9 @@ class GoldClusterizer:
             raise ValueError("chunk must be a positive integer or None.")
         self.chunk = chunk
         self.collate_fn = (
-            collate_fn if collate_fn is not None else pxt_torch_dataset_collate_fn
+            collate_fn
+            if collate_fn is not None
+            else collate_keeping_sequences_as_sequences
         )
         self.vectorized_key = vectorized_key
         self.include_vectorized_in_table = include_vectorized_in_table

--- a/goldener/clusterize.py
+++ b/goldener/clusterize.py
@@ -238,7 +238,7 @@ class GoldClusterizer:
         collate_fn: Optional function to collate dataset samples into batches composed of
             dictionaries with at least the key specified by `vectorized_key` returning a PyTorch Tensor.
             If None, `collate_keeping_sequences_as_sequences` is used, which preserves sequence-valued
-            fields as one list per sample.
+            fields as one sequence per sample.
         vectorized_key: Key in the batch dictionary that contains the vectorized data for the clustering. Default is "vectorized".
         include_vectorized_in_table: Whether to keep the vectorized data in the cluster table.
             It is only applied if the cluster table is created from a Table (it is forced anyway for Dataset). Default is False.
@@ -293,7 +293,7 @@ class GoldClusterizer:
             collate_fn: Optional function to collate dataset samples into batches composed of
                 dictionaries with at least the key specified by `vectorized_key` returning a PyTorch Tensor.
                 If None, `collate_keeping_sequences_as_sequences` is used, which preserves sequence-valued
-                fields as one list per sample.
+                fields as one sequence per sample.
             vectorized_key: Key in the batch dictionary that contains the vectorized data for the clustering. Default is "vectorized".
             include_vectorized_in_table: Whether to keep the vectorized data in the cluster table. Defaults to False.
                     It is only applied if the cluster table is created from a Table (it is forced anyway for Dataset).

--- a/goldener/describe.py
+++ b/goldener/describe.py
@@ -59,7 +59,7 @@ class GoldDescriptor:
         collate_fn: Optional function to collate dataset samples into batches composed of
             dictionaries with at least the key specified by `data_key` returning a PyTorch Tensor.
             If None, `collate_keeping_sequences_as_sequences` is used, which preserves sequence-valued
-            fields as one list per sample. It should format
+            fields as one sequence per sample. It should format
             the value at `data_key` in the format expected by the embedder.
         data_key: Key in the batch dictionary that contains the data to compute embeddings from. Default is "data".
         target_key: Key in the batch dictionary that contains the target/label information. Default is "target".

--- a/goldener/describe.py
+++ b/goldener/describe.py
@@ -14,13 +14,15 @@ from goldener.pxt_utils import (
     GoldPxtTorchDataset,
     get_expr_from_column_name,
     get_sample_row_from_idx,
-    pxt_torch_dataset_collate_fn,
     get_valid_table,
     make_batch_ready_for_table,
     check_pxt_table_has_primary_key,
     get_max_value_in_column,
 )
-from goldener.torch_utils import get_dataset_sample_dict
+from goldener.torch_utils import (
+    collate_keeping_sequences_as_sequences,
+    get_dataset_sample_dict,
+)
 from goldener.utils import filter_batch_from_indices
 from goldener.vectorize import (
     GoldTensorVectorizationTool,
@@ -56,7 +58,7 @@ class GoldDescriptor:
             applied by the `collate_fn`.
         collate_fn: Optional function to collate dataset samples into batches composed of
             dictionaries with at least the key specified by `data_key` returning a PyTorch Tensor.
-            If None, `pxt_torch_dataset_collate_fn` is used, which preserves list-valued
+            If None, `collate_keeping_sequences_as_sequences` is used, which preserves sequence-valued
             fields as one list per sample. It should format
             the value at `data_key` in the format expected by the embedder.
         data_key: Key in the batch dictionary that contains the data to compute embeddings from. Default is "data".
@@ -122,7 +124,7 @@ class GoldDescriptor:
             vectorizer: Optional GoldTensorVectorizationTool to further vectorize the computed embeddings.
             transform: Optional transformation to apply before embedding computation.
             collate_fn: Optional function to collate dataset samples into batches.
-                If None, `pxt_torch_dataset_collate_fn` is used.
+                If None, `collate_keeping_sequences_as_sequences` is used.
             data_key: Key in the batch dictionary containing the data. Defaults to "data".
             target_key: Key in the batch dictionary containing the target/label. Defaults to "target".
             label_key: Optional key for labels in the batch dictionary. Default is None.
@@ -152,7 +154,9 @@ class GoldDescriptor:
         self.vectorizer = vectorizer
         self.transform = transform
         self.collate_fn = (
-            collate_fn if collate_fn is not None else pxt_torch_dataset_collate_fn
+            collate_fn
+            if collate_fn is not None
+            else collate_keeping_sequences_as_sequences
         )
         self.data_key = data_key
         self.target_key = target_key
@@ -355,7 +359,7 @@ class GoldDescriptor:
             logger.info(f"Add the description column in {self.table_path}")
             sample = get_sample_row_from_idx(
                 to_describe,
-                collate_fn=pxt_torch_dataset_collate_fn,
+                collate_fn=collate_keeping_sequences_as_sequences,
                 expected_keys=[self.data_key],
             )
             sample_data = sample[self.data_key]

--- a/goldener/pxt_utils.py
+++ b/goldener/pxt_utils.py
@@ -1,8 +1,6 @@
-from collections import defaultdict
-from typing import Literal, Any, Iterator, Sequence, Callable
+from typing import Literal, Any, Iterator, Callable
 import shutil
 
-import numpy as np
 import pixeltable as pxt
 from pixeltable import Query
 from pixeltable.catalog import Table
@@ -120,45 +118,6 @@ def set_value_to_idx_rows(
         value: The value to set the column to.
     """
     table.where(idx_expr.isin(indices)).update({col_expr.display_str(): value})
-
-
-def pxt_torch_dataset_collate_fn(batch: list[dict[str, Any]]) -> dict[str, Any]:
-    """Collate function for torch datasets obtained from a Pixeltable table.
-
-    Args:
-        batch: A list of samples, where each sample is a dictionary.
-
-    Returns:
-        A single dictionary with collated values. The torch tensors, numpy arrays and
-        integers are stacked into torch tensors. All other types are kept as lists.
-    """
-    value_list_dict = defaultdict(list)
-    conversion_dict: dict[str, Callable[[Sequence[Any]], torch.Tensor]] = {}
-
-    def stack_arrays_and_convert_to_torch(arrays: Sequence[np.ndarray]) -> torch.Tensor:
-        return torch.from_numpy(np.stack(arrays, axis=0))
-
-    def stack_int_as_torch(ints: Sequence[int]) -> torch.Tensor:
-        return torch.tensor(ints, dtype=torch.int64)
-
-    def stack_tensors(tensors: Sequence[torch.Tensor]) -> torch.Tensor:
-        return torch.stack(list(tensors), dim=0)
-
-    for idx_sample, sample in enumerate(batch):
-        for key, value in sample.items():
-            value_list_dict[key].append(value)
-            if idx_sample == 0:
-                if isinstance(value, torch.Tensor):
-                    conversion_dict[key] = stack_tensors
-                elif isinstance(value, np.ndarray):
-                    conversion_dict[key] = stack_arrays_and_convert_to_torch
-                elif isinstance(value, int):
-                    conversion_dict[key] = stack_int_as_torch
-
-    return {
-        key: conversion_dict[key](value) if key in conversion_dict else value
-        for key, value in value_list_dict.items()
-    }
 
 
 class GoldPxtTorchDataset(PixeltablePytorchDataset):

--- a/goldener/select.py
+++ b/goldener/select.py
@@ -655,7 +655,7 @@ class GoldSelector:
         collate_fn: Optional function to collate dataset samples into batches composed of
             dictionaries with at least the key specified by `vectorized_key` returning a PyTorch Tensor.
             If None, `collate_keeping_sequences_as_sequences` is used, which preserves sequence-valued
-            fields as one list per sample.
+            fields as one sequence per sample.
         vectorized_key: Key in the batch dictionary that contains the vectorized data for selection. Default is "vectorized".
         include_vectorized_in_table: Whether to include the vectorized data in the selection table. Defaults to False.
         It is only applied if the cluster table is created from a Table (it is forced anyway for Dataset).

--- a/goldener/select.py
+++ b/goldener/select.py
@@ -30,10 +30,12 @@ from goldener.pxt_utils import (
     make_batch_ready_for_table,
     check_pxt_table_has_primary_key,
     get_sample_row_from_idx,
-    pxt_torch_dataset_collate_fn,
 )
 from goldener.reduce import GoldReductionTool, GoldReductionToolWithFit
-from goldener.torch_utils import get_dataset_sample_dict
+from goldener.torch_utils import (
+    collate_keeping_sequences_as_sequences,
+    get_dataset_sample_dict,
+)
 from goldener.utils import (
     filter_batch_from_indices,
     get_indices_with_labels,
@@ -652,7 +654,7 @@ class GoldSelector:
         chunk: Optional chunk size for processing data in chunks to reduce memory consumption.
         collate_fn: Optional function to collate dataset samples into batches composed of
             dictionaries with at least the key specified by `vectorized_key` returning a PyTorch Tensor.
-            If None, `pxt_torch_dataset_collate_fn` is used, which preserves list-valued
+            If None, `collate_keeping_sequences_as_sequences` is used, which preserves sequence-valued
             fields as one list per sample.
         vectorized_key: Key in the batch dictionary that contains the vectorized data for selection. Default is "vectorized".
         include_vectorized_in_table: Whether to include the vectorized data in the selection table. Defaults to False.
@@ -710,7 +712,7 @@ class GoldSelector:
             reducer: Optional GoldReductionTool instance for dimensionality reduction before selection.
             chunk: Optional chunk size for processing data in chunks.
             collate_fn: Optional collate function for the DataLoader.
-                If None, `pxt_torch_dataset_collate_fn` is used.
+                If None, `collate_keeping_sequences_as_sequences` is used.
             vectorized_key: Key pointing to the vector for selection. Defaults to "vectorized".
             include_vectorized_in_table: Whether to include the vectorized data in the selection table. Defaults to False.
                 It is only applied if the selection table is created from a Table (it is forced anyway for Dataset).
@@ -736,7 +738,9 @@ class GoldSelector:
         self.reducer = reducer
         self.chunk = chunk
         self.collate_fn = (
-            collate_fn if collate_fn is not None else pxt_torch_dataset_collate_fn
+            collate_fn
+            if collate_fn is not None
+            else collate_keeping_sequences_as_sequences
         )
         self.vectorized_key = vectorized_key
         self.include_vectorized_in_table = include_vectorized_in_table

--- a/goldener/split.py
+++ b/goldener/split.py
@@ -14,9 +14,9 @@ from goldener.pxt_utils import (
     get_expr_from_column_name,
     set_value_to_idx_rows,
     GoldPxtTorchDataset,
-    pxt_torch_dataset_collate_fn,
 )
 from goldener.select import GoldSelector
+from goldener.torch_utils import collate_keeping_sequences_as_sequences
 from goldener.utils import (
     check_sampling_size,
     check_all_same_type,
@@ -298,7 +298,7 @@ class GoldSplitter:
             num_workers: Number of workers to use when processing the input as dataset.
             collate_fn: Collate function to use when processing the input as dataset. It should
                 return a dictionary with at least the keys specified by `idx_key` and `selection_key`.
-                If None, `pxt_torch_dataset_collate_fn` is used.
+                If None, `collate_keeping_sequences_as_sequences` is used.
 
         Returns:
             A dictionary mapping each set name to a set of sample indices.
@@ -314,7 +314,7 @@ class GoldSplitter:
                 collate_fn=(
                     collate_fn
                     if collate_fn is not None
-                    else pxt_torch_dataset_collate_fn
+                    else collate_keeping_sequences_as_sequences
                 ),
             )
 
@@ -551,16 +551,17 @@ class GoldSplitter:
         gold_set: GoldSet,
     ) -> Table:
         assert self.clusterizer is not None
-        # the table for each cluster are processed sequentially, and sent as GoldPxtTorchDataset
-        # to the selector, so the collate_fn of the selector is temporarily updated to `pxt_torch_dataset_collate_fn,
-        # and reset to the original collate_fn after the cluster-wise selection is done
+        # Cluster tables are processed sequentially as GoldPxtTorchDataset instances.
+        # The selector temporarily uses `collate_keeping_sequences_as_sequences`, then
+        # restores its original collate function after cluster-wise selection.
         selection_collate_fn = self.selector.collate_fn
         logger.info(
             "Clusterized selection is enabled. Temporarily setting selector's collate_fn "
-            "to pxt_torch_dataset_collate_fn to process cluster-wise selection. "
+            "to collate_keeping_sequences_as_sequences to process cluster-wise "
+            "selection. "
             "It will be reset to the original collate_fn after the cluster-wise selection is done."
         )
-        self.selector.collate_fn = pxt_torch_dataset_collate_fn
+        self.selector.collate_fn = collate_keeping_sequences_as_sequences
 
         try:
             # validate the clustering has been run

--- a/goldener/torch_utils.py
+++ b/goldener/torch_utils.py
@@ -1,11 +1,40 @@
+from collections import defaultdict
+from collections.abc import Sequence
 from typing import Callable, Any, Iterator, TypeVar
 
 import numpy as np
 import torch
-from torch.utils.data import IterableDataset, Dataset
+from torch.utils.data import IterableDataset, Dataset, default_collate
 
 
 T = TypeVar("T")
+
+
+def collate_keeping_sequences_as_sequences(
+    batch: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Collate dictionary samples while preserving sequence-valued features.
+
+    Args:
+        batch: A list of samples, where each sample is a dictionary.
+
+    Returns:
+        A dictionary with sequences kept per sample and all other values collated
+        with PyTorch's default collate function.
+    """
+    values_by_key: dict[str, list[Any]] = defaultdict(list)
+    for sample in batch:
+        for key, value in sample.items():
+            values_by_key[key].append(value)
+
+    return {
+        key: (
+            values
+            if isinstance(values[0], Sequence) or values[0] is None
+            else default_collate(values)
+        )
+        for key, values in values_by_key.items()
+    }
 
 
 def make_2d_tensor(x: torch.Tensor) -> torch.Tensor:

--- a/goldener/torch_utils.py
+++ b/goldener/torch_utils.py
@@ -1,5 +1,5 @@
-from collections import defaultdict
 from collections.abc import Sequence
+from logging import getLogger
 from typing import Callable, Any, Iterator, TypeVar
 
 import numpy as np
@@ -7,6 +7,7 @@ import torch
 from torch.utils.data import IterableDataset, Dataset, default_collate
 
 
+logger = getLogger(__name__)
 T = TypeVar("T")
 
 
@@ -21,11 +22,25 @@ def collate_keeping_sequences_as_sequences(
     Returns:
         A dictionary with sequences kept per sample and all other values collated
         with PyTorch's default collate function.
+
+    Raises:
+        KeyError: If a sample is missing a key present in the first sample.
     """
-    values_by_key: dict[str, list[Any]] = defaultdict(list)
-    for sample in batch:
-        for key, value in sample.items():
-            values_by_key[key].append(value)
+    if not batch:
+        return {}
+
+    values_by_key = {key: [value] for key, value in batch[0].items()}
+    for sample_idx, sample in enumerate(batch[1:], start=1):
+        for key in values_by_key:
+            values_by_key[key].append(sample[key])
+
+        extra_keys = sample.keys() - values_by_key.keys()
+        if extra_keys:
+            logger.warning(
+                "Ignoring extra keys %s in batch sample at index %d.",
+                sorted(extra_keys),
+                sample_idx,
+            )
 
     return {
         key: (

--- a/goldener/torch_utils.py
+++ b/goldener/torch_utils.py
@@ -37,9 +37,7 @@ def collate_keeping_sequences_as_sequences(
         extra_keys = sample.keys() - values_by_key.keys()
         if extra_keys:
             logger.warning(
-                "Ignoring extra keys %s in batch sample at index %d.",
-                sorted(extra_keys),
-                sample_idx,
+                f"Ignoring extra keys {sorted(extra_keys)} in batch sample at index {sample_idx}.",
             )
 
     return {

--- a/goldener/vectorize.py
+++ b/goldener/vectorize.py
@@ -478,7 +478,7 @@ class GoldVectorizer:
         collate_fn: Optional function to collate dataset samples into batches composed of
             dictionaries with at least the key specified by `data_key` returning a PyTorch Tensor.
             If None, `collate_keeping_sequences_as_sequences` is used, which preserves sequence-valued
-            fields as one list per sample.
+            fields as one sequence per sample.
         data_key: Key in the batch dictionary that contains the data to vectorize. Default is "embeddings".
         target_key: Optional key in the batch dictionary containing the target used to filter vectors. Default is "target".
         vectorized_key: Column name to store the resulting vectors in the PixelTable table. Default is "vectorized".

--- a/goldener/vectorize.py
+++ b/goldener/vectorize.py
@@ -22,13 +22,16 @@ from goldener.pxt_utils import (
     GoldPxtTorchDataset,
     get_valid_table,
     get_sample_row_from_idx,
-    pxt_torch_dataset_collate_fn,
     get_expr_from_column_name,
     make_batch_ready_for_table,
     check_pxt_table_has_primary_key,
     get_max_value_in_column,
 )
-from goldener.torch_utils import make_2d_tensor, get_dataset_sample_dict
+from goldener.torch_utils import (
+    collate_keeping_sequences_as_sequences,
+    get_dataset_sample_dict,
+    make_2d_tensor,
+)
 from goldener.utils import (
     check_x_and_y_shapes,
     filter_batch_from_indices,
@@ -474,7 +477,7 @@ class GoldVectorizer:
         vectorizer: GoldTensorVectorizationTool instance for transforming batched inputs into vectors.
         collate_fn: Optional function to collate dataset samples into batches composed of
             dictionaries with at least the key specified by `data_key` returning a PyTorch Tensor.
-            If None, `pxt_torch_dataset_collate_fn` is used, which preserves list-valued
+            If None, `collate_keeping_sequences_as_sequences` is used, which preserves sequence-valued
             fields as one list per sample.
         data_key: Key in the batch dictionary that contains the data to vectorize. Default is "embeddings".
         target_key: Optional key in the batch dictionary containing the target used to filter vectors. Default is "target".
@@ -530,7 +533,7 @@ class GoldVectorizer:
             table_path: Path to the PixelTable table for storing vectors.
             vectorizer: GoldTensorVectorizationTool instance for transforming tensors.
             collate_fn: Optional collate function for preparing batches.
-                If None, `pxt_torch_dataset_collate_fn` is used.
+                If None, `collate_keeping_sequences_as_sequences` is used.
             data_key: Key for data in the batch dictionary. Defaults to "embeddings".
             target_key: Key for target in the batch dictionary. Defaults to "target".
             vectorized_key: Column name for storing vectors. Defaults to "vectorized".
@@ -555,7 +558,9 @@ class GoldVectorizer:
         self.table_path = table_path
         self.vectorizer = vectorizer
         self.collate_fn = (
-            collate_fn if collate_fn is not None else pxt_torch_dataset_collate_fn
+            collate_fn
+            if collate_fn is not None
+            else collate_keeping_sequences_as_sequences
         )
         self.data_key = data_key
         self.target_key = target_key
@@ -752,7 +757,7 @@ class GoldVectorizer:
             logger.info(f"Add the Vectorized column in {self.table_path}")
             sample = get_sample_row_from_idx(
                 to_vectorize,
-                collate_fn=pxt_torch_dataset_collate_fn,
+                collate_fn=collate_keeping_sequences_as_sequences,
                 expected_keys=[self.data_key],
             )
             vectorized = self.vectorizer.vectorize(

--- a/tests/test_clusterize.py
+++ b/tests/test_clusterize.py
@@ -11,7 +11,8 @@ from goldener.clusterize import (
     get_random_chunk_assignment,
 )
 from goldener.reduce import GoldSKLearnReductionTool
-from goldener.pxt_utils import GoldPxtTorchDataset, pxt_torch_dataset_collate_fn
+from goldener.pxt_utils import GoldPxtTorchDataset
+from goldener.torch_utils import collate_keeping_sequences_as_sequences
 
 
 class DummyDataset(Dataset):
@@ -262,12 +263,12 @@ class TestGoldClusterizer:
             clusterizer.distribute = True
         assert clusterizer.distribute is False
 
-    def test_collate_fn_defaults_to_pxt_torch_dataset_collate_fn(self):
+    def test_collate_fn_defaults_to_collate_keeping_sequences_as_sequences(self):
         clusterizer = GoldClusterizer(
             table_path="unit_test.cluster_default_collate",
             clustering_tool=GoldRandomClusteringTool(),
         )
-        assert clusterizer.collate_fn is pxt_torch_dataset_collate_fn
+        assert clusterizer.collate_fn is collate_keeping_sequences_as_sequences
 
         def custom_collate_fn(batch):
             return batch

--- a/tests/test_describe.py
+++ b/tests/test_describe.py
@@ -8,7 +8,7 @@ import pixeltable as pxt
 
 from goldener.describe import GoldDescriptor
 from goldener.embed import GoldTorchEmbeddingToolConfig, GoldTorchEmbeddingTool
-from goldener.pxt_utils import pxt_torch_dataset_collate_fn
+from goldener.torch_utils import collate_keeping_sequences_as_sequences
 from goldener.vectorize import GoldTensorVectorizationTool
 
 
@@ -783,12 +783,14 @@ class TestGoldDescriptor:
         assert labels_by_idx[0] == {"class_1", "class_2"}
         assert labels_by_idx[1] == {"class_1", "class_2"}
 
-    def test_collate_fn_defaults_to_pxt_torch_dataset_collate_fn(self, embedder):
+    def test_collate_fn_defaults_to_collate_keeping_sequences_as_sequences(
+        self, embedder
+    ):
         desc = GoldDescriptor(
             table_path="unit_test.test_describe",
             embedder=embedder,
         )
-        assert desc.collate_fn is pxt_torch_dataset_collate_fn
+        assert desc.collate_fn is collate_keeping_sequences_as_sequences
 
         def custom_collate_fn(batch):
             return batch

--- a/tests/test_organize.py
+++ b/tests/test_organize.py
@@ -15,7 +15,7 @@ from goldener.organize import (
     ExhaustedClusterStrategy,
     get_indices_per_cluster_for_subset,
 )
-from goldener.pxt_utils import pxt_torch_dataset_collate_fn
+from goldener.torch_utils import collate_keeping_sequences_as_sequences
 from goldener.vectorize import GoldVectorizer, GoldTensorVectorizationTool
 
 
@@ -54,7 +54,7 @@ def vectorizer():
     return GoldVectorizer(
         table_path="unit_test.vectorizer_batcher",
         vectorizer=GoldTensorVectorizationTool(),
-        collate_fn=pxt_torch_dataset_collate_fn,
+        collate_fn=collate_keeping_sequences_as_sequences,
         batch_size=2,
     )
 

--- a/tests/test_pxt_utils.py
+++ b/tests/test_pxt_utils.py
@@ -12,7 +12,6 @@ from goldener.pxt_utils import (
     get_expr_from_column_name,
     create_pxt_dirs_for_path,
     set_value_to_idx_rows,
-    pxt_torch_dataset_collate_fn,
     get_distinct_value_and_count_in_column,
     get_column_distinct_ratios,
     get_array_column_shapes_from_table,
@@ -198,51 +197,6 @@ class TestSetValueToIdxRows:
         assert result_a[0]["idx"] == 1
 
         pxt.drop_dir("test_set_value", force=True)
-
-
-class TestPxtTorchDatasetCollateFn:
-    def test_collate_numpy_arrays(self):
-        batch = [
-            {"image": np.array([1, 2, 3]), "label": 0, "text": "hello"},
-            {"image": np.array([4, 5, 6]), "label": 1, "text": "world"},
-        ]
-
-        result = pxt_torch_dataset_collate_fn(batch)
-
-        assert "image" in result
-        assert "label" in result
-        assert isinstance(result["image"], torch.Tensor)
-        assert isinstance(result["label"], torch.Tensor)
-        assert isinstance(result["text"], list)
-        assert result["text"] == ["hello", "world"]
-        assert result["image"].shape == (2, 3)
-        assert torch.equal(result["label"], torch.tensor([0, 1], dtype=torch.int64))
-
-    def test_collate_tensors(self):
-        batch = [
-            {"data": torch.zeros(3, 4)},
-            {"data": torch.ones(3, 4)},
-        ]
-
-        result = pxt_torch_dataset_collate_fn(batch)
-
-        assert isinstance(result["data"], torch.Tensor)
-        assert result["data"].shape == (2, 3, 4)
-
-    def test_collate_keeps_multilabel_lists_per_sample(self):
-        batch = [
-            {"label": ["class_1", "class_2"]},
-            {"label": ["class_1", "class_2"]},
-        ]
-
-        result = pxt_torch_dataset_collate_fn(batch)
-
-        assert result["label"] == [["class_1", "class_2"], ["class_1", "class_2"]]
-
-    def test_collate_empty_batch(self):
-        batch = []
-        result = pxt_torch_dataset_collate_fn(batch)
-        assert result == {}
 
 
 class TestGetDistinctValueAndCountInColumn:

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -11,7 +11,7 @@ from sklearn.decomposition import PCA
 import pixeltable as pxt
 from torch.utils.data import Dataset
 
-from goldener.pxt_utils import GoldPxtTorchDataset, pxt_torch_dataset_collate_fn
+from goldener.pxt_utils import GoldPxtTorchDataset
 from goldener.reduce import GoldSKLearnReductionTool
 from goldener.select import (
     GoldSelector,
@@ -24,6 +24,7 @@ from goldener.select import (
     GoldGreedyKernelPointsSelectionTool,
     GoldZCoreSelectionTool,
 )
+from goldener.torch_utils import collate_keeping_sequences_as_sequences
 
 
 class DummyDataset(Dataset):
@@ -64,9 +65,9 @@ class TestGoldSelector:
             selector.distribute = True
         assert selector.distribute is False
 
-    def test_collate_fn_defaults_to_pxt_torch_dataset_collate_fn(self):
+    def test_collate_fn_defaults_to_collate_keeping_sequences_as_sequences(self):
         selector = GoldSelector(table_path="unit_test.select_default_collate")
-        assert selector.collate_fn is pxt_torch_dataset_collate_fn
+        assert selector.collate_fn is collate_keeping_sequences_as_sequences
 
         def custom_collate_fn(batch):
             return batch

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -8,7 +8,7 @@ from torch.utils.data import Dataset
 from goldener.clusterize import GoldClusterizer, GoldRandomClusteringTool
 from goldener.describe import GoldDescriptor
 from goldener.embed import GoldTorchEmbeddingToolConfig, GoldTorchEmbeddingTool
-from goldener.pxt_utils import pxt_torch_dataset_collate_fn
+from goldener.torch_utils import collate_keeping_sequences_as_sequences
 from goldener.split import GoldSplitter, GoldSet, check_sets_validity
 from goldener.vectorize import GoldTensorVectorizationTool, GoldVectorizer
 from goldener.select import GoldSelector
@@ -73,7 +73,7 @@ def vectorizer():
         table_path="unit_test.vectorizer_split",
         vectorizer=GoldTensorVectorizationTool(),
         to_keep_schema={"label": pxt.String},
-        collate_fn=pxt_torch_dataset_collate_fn,
+        collate_fn=collate_keeping_sequences_as_sequences,
         batch_size=2,
     )
 
@@ -98,9 +98,9 @@ class TestGoldSplitter:
         splitted = GoldSplitter.get_split_indices(
             DummyDataset(
                 [
+                    {"idx": 2, "selected": None},
                     {"idx": 0, "selected": "train"},
                     {"idx": 1, "selected": "val"},
-                    {"idx": 2, "selected": None},
                 ]
             ),
             selection_key="selected",

--- a/tests/test_torch_utils.py
+++ b/tests/test_torch_utils.py
@@ -2,7 +2,10 @@ import numpy as np
 import torch
 import pytest
 from collections import Counter
+from torch.utils.data import default_collate
+
 from goldener.torch_utils import (
+    collate_keeping_sequences_as_sequences,
     torch_tensor_to_numpy_vectors,
     numpy_vectors_to_torch_tensor,
     np_transform_from_torch,
@@ -11,6 +14,64 @@ from goldener.torch_utils import (
     get_unique_values_in_tensor,
     shuffle_list,
 )
+
+
+class TestCollateKeepingSequencesAsSequences:
+    def test_collates_numpy_arrays_and_integers(self):
+        batch = [
+            {"image": np.array([1, 2, 3]), "label": 0, "text": "hello"},
+            {"image": np.array([4, 5, 6]), "label": 1, "text": "world"},
+        ]
+
+        result = collate_keeping_sequences_as_sequences(batch)
+
+        assert isinstance(result["image"], torch.Tensor)
+        assert isinstance(result["label"], torch.Tensor)
+        assert result["text"] == ["hello", "world"]
+        assert result["image"].shape == (2, 3)
+        assert result["label"].dtype == torch.int64
+        assert torch.equal(result["label"], torch.tensor([0, 1], dtype=torch.int64))
+
+    def test_collates_tensors(self):
+        batch = [
+            {"data": torch.zeros(3, 4)},
+            {"data": torch.ones(3, 4)},
+        ]
+
+        result = collate_keeping_sequences_as_sequences(batch)
+
+        assert isinstance(result["data"], torch.Tensor)
+        assert result["data"].shape == (2, 3, 4)
+
+    def test_collates_other_non_sequences_with_default_collate(self):
+        batch = [
+            {"float": 1.5, "bool": True, "numpy_scalar": np.float32(2.5)},
+            {"float": 3.5, "bool": False, "numpy_scalar": np.float32(4.5)},
+        ]
+
+        result = collate_keeping_sequences_as_sequences(batch)
+
+        for key in batch[0]:
+            expected = default_collate([sample[key] for sample in batch])
+            assert result[key].dtype == expected.dtype
+            assert torch.equal(result[key], expected)
+
+    def test_keeps_sequences_per_sample(self):
+        batch = [
+            {"labels": ["class_1", "class_2"], "metadata": ("first",)},
+            {
+                "labels": ["class_1", "class_2"],
+                "metadata": ("second", "extra"),
+            },
+        ]
+
+        result = collate_keeping_sequences_as_sequences(batch)
+
+        assert result["labels"] == [sample["labels"] for sample in batch]
+        assert result["metadata"] == [sample["metadata"] for sample in batch]
+
+    def test_empty_batch(self):
+        assert collate_keeping_sequences_as_sequences([]) == {}
 
 
 class TestTorchTensorToNumpyVectors:

--- a/tests/test_torch_utils.py
+++ b/tests/test_torch_utils.py
@@ -17,32 +17,6 @@ from goldener.torch_utils import (
 
 
 class TestCollateKeepingSequencesAsSequences:
-    def test_collates_numpy_arrays_and_integers(self):
-        batch = [
-            {"image": np.array([1, 2, 3]), "label": 0, "text": "hello"},
-            {"image": np.array([4, 5, 6]), "label": 1, "text": "world"},
-        ]
-
-        result = collate_keeping_sequences_as_sequences(batch)
-
-        assert isinstance(result["image"], torch.Tensor)
-        assert isinstance(result["label"], torch.Tensor)
-        assert result["text"] == ["hello", "world"]
-        assert result["image"].shape == (2, 3)
-        assert result["label"].dtype == torch.int64
-        assert torch.equal(result["label"], torch.tensor([0, 1], dtype=torch.int64))
-
-    def test_collates_tensors(self):
-        batch = [
-            {"data": torch.zeros(3, 4)},
-            {"data": torch.ones(3, 4)},
-        ]
-
-        result = collate_keeping_sequences_as_sequences(batch)
-
-        assert isinstance(result["data"], torch.Tensor)
-        assert result["data"].shape == (2, 3, 4)
-
     def test_collates_other_non_sequences_with_default_collate(self):
         batch = [
             {"float": 1.5, "bool": True, "numpy_scalar": np.float32(2.5)},
@@ -69,6 +43,30 @@ class TestCollateKeepingSequencesAsSequences:
 
         assert result["labels"] == [sample["labels"] for sample in batch]
         assert result["metadata"] == [sample["metadata"] for sample in batch]
+
+    def test_raises_when_sample_is_missing_key(self):
+        batch = [
+            {"value": 1, "label": "first"},
+            {"value": 2},
+        ]
+
+        with pytest.raises(KeyError, match="label"):
+            collate_keeping_sequences_as_sequences(batch)
+
+    def test_warns_and_ignores_extra_keys(self, caplog):
+        batch = [
+            {"value": 1},
+            {"value": 2, "extra": "ignored"},
+        ]
+
+        with caplog.at_level("WARNING", logger="goldener.torch_utils"):
+            result = collate_keeping_sequences_as_sequences(batch)
+
+        assert set(result) == {"value"}
+        assert torch.equal(result["value"], torch.tensor([1, 2]))
+        assert (
+            "Ignoring extra keys ['extra'] in batch sample at index 1." in caplog.text
+        )
 
     def test_empty_batch(self):
         assert collate_keeping_sequences_as_sequences([]) == {}

--- a/tests/test_vectorize.py
+++ b/tests/test_vectorize.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 import torch
 import pytest
 import pixeltable as pxt
-from goldener.pxt_utils import pxt_torch_dataset_collate_fn
+from goldener.torch_utils import collate_keeping_sequences_as_sequences
 from goldener.vectorize import (
     GoldTensorVectorizationTool,
     Filter2DWithCount,
@@ -481,12 +481,12 @@ class TestGoldVectorizer:
             vectorizer.distribute = True
         assert vectorizer.distribute is False
 
-    def test_collate_fn_defaults_to_pxt_torch_dataset_collate_fn(self):
+    def test_collate_fn_defaults_to_collate_keeping_sequences_as_sequences(self):
         gv = GoldVectorizer(
             table_path="unit_test.vectorize_default_collate",
             vectorizer=GoldTensorVectorizationTool(),
         )
-        assert gv.collate_fn is pxt_torch_dataset_collate_fn
+        assert gv.collate_fn is collate_keeping_sequences_as_sequences
 
         def custom_collate_fn(batch):
             return batch


### PR DESCRIPTION
Closes #254.

This moves the sequence-preserving collator to `torch_utils`, renames it
to
    `collate_keeping_sequences_as_sequences`, and delegates non-sequence
fields to PyTorch's `default_collate`.
All existing call sites and GoldDoer defaults use the generalized helper.