### PR TITLE
Validate restriction index key in selector and clusterizer

### DIFF
--- a/goldener/clusterize.py
+++ b/goldener/clusterize.py
@@ -436,8 +436,14 @@ class GoldClusterizer:
                 and `idx` (index of the sample) and `idx_vector` (index of the vector) columns as well.
 
         Raises:
-            ValueError: If n_clusters is less than or equal to 1.
+            ValueError: If `restriction_idx_key` is not `"idx"` or `"idx_vector"`,
+                or if n_clusters is less than or equal to 1.
         """
+        if restriction_idx_key not in ("idx", "idx_vector"):
+            raise ValueError(
+                "restriction_idx_key must be either 'idx' or 'idx_vector'."
+            )
+
         if n_clusters <= 1:
             raise ValueError(
                 "cluster_in_table requires n_clusters to be greater than 1."

--- a/goldener/select.py
+++ b/goldener/select.py
@@ -911,8 +911,14 @@ class GoldSelector:
                 and `idx` (index of the sample) and `idx_vector` (index of the vector) columns as well.
 
         Raises:
-            ValueError: If select_size is a float not in the range ]0.0, 1.0].
+            ValueError: If `restriction_idx_key` is not `"idx"` or `"idx_vector"`,
+                or if select_size is a float not in the range ]0.0, 1.0].
         """
+        if restriction_idx_key not in ("idx", "idx_vector"):
+            raise ValueError(
+                "restriction_idx_key must be either 'idx' or 'idx_vector'."
+            )
+
         if isinstance(select_size, float):
             if not (0.0 < select_size <= 1.0):
                 raise ValueError(

--- a/tests/test_clusterize.py
+++ b/tests/test_clusterize.py
@@ -481,6 +481,54 @@ class TestGoldClusterizer:
         with pytest.raises(ValueError, match="n_clusters to be greater than 1"):
             clusterizer.cluster_in_table(dataset, n_clusters=1)
 
+    def test_cluster_in_table_with_invalid_restriction_idx_key(self):
+        table_path = "unit_test.test_cluster_invalid_restriction_idx_key"
+        clusterizer = GoldClusterizer(
+            table_path=table_path,
+            clustering_tool=GoldRandomClusteringTool(random_state=0),
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="restriction_idx_key must be either 'idx' or 'idx_vector'",
+        ):
+            clusterizer.cluster_in_table(
+                DummyDataset([]),
+                n_clusters=2,
+                restrict_to={0},
+                restriction_idx_key="invalid",
+            )
+
+        with pytest.raises(pxt.Error):
+            pxt.get_table(table_path)
+
+    @pytest.mark.parametrize("restriction_idx_key", ["idx", "idx_vector"])
+    def test_cluster_in_table_with_valid_restriction_idx_key(self, restriction_idx_key):
+        table_path = f"unit_test.test_cluster_restrict_{restriction_idx_key}"
+        dataset = DummyDataset(
+            [{"vectorized": torch.rand(4), "idx": idx} for idx in range(10)]
+        )
+        clusterizer = GoldClusterizer(
+            table_path=table_path,
+            clustering_tool=GoldRandomClusteringTool(random_state=0),
+            batch_size=5,
+        )
+
+        cluster_table = clusterizer.cluster_in_table(
+            dataset,
+            n_clusters=3,
+            restrict_to={2, 5, 7},
+            restriction_idx_key=restriction_idx_key,
+        )
+
+        assert cluster_table.count() == 3
+        assert {
+            row[restriction_idx_key]
+            for row in cluster_table.select(
+                cluster_table[restriction_idx_key]
+            ).collect()
+        } == {2, 5, 7}
+
     def test_cluster_in_table_with_chunk(self):
         table_path = "unit_test.test_cluster_chunk"
 

--- a/tests/test_clusterize.py
+++ b/tests/test_clusterize.py
@@ -481,54 +481,6 @@ class TestGoldClusterizer:
         with pytest.raises(ValueError, match="n_clusters to be greater than 1"):
             clusterizer.cluster_in_table(dataset, n_clusters=1)
 
-    def test_cluster_in_table_with_invalid_restriction_idx_key(self):
-        table_path = "unit_test.test_cluster_invalid_restriction_idx_key"
-        clusterizer = GoldClusterizer(
-            table_path=table_path,
-            clustering_tool=GoldRandomClusteringTool(random_state=0),
-        )
-
-        with pytest.raises(
-            ValueError,
-            match="restriction_idx_key must be either 'idx' or 'idx_vector'",
-        ):
-            clusterizer.cluster_in_table(
-                DummyDataset([]),
-                n_clusters=2,
-                restrict_to={0},
-                restriction_idx_key="invalid",
-            )
-
-        with pytest.raises(pxt.Error):
-            pxt.get_table(table_path)
-
-    @pytest.mark.parametrize("restriction_idx_key", ["idx", "idx_vector"])
-    def test_cluster_in_table_with_valid_restriction_idx_key(self, restriction_idx_key):
-        table_path = f"unit_test.test_cluster_restrict_{restriction_idx_key}"
-        dataset = DummyDataset(
-            [{"vectorized": torch.rand(4), "idx": idx} for idx in range(10)]
-        )
-        clusterizer = GoldClusterizer(
-            table_path=table_path,
-            clustering_tool=GoldRandomClusteringTool(random_state=0),
-            batch_size=5,
-        )
-
-        cluster_table = clusterizer.cluster_in_table(
-            dataset,
-            n_clusters=3,
-            restrict_to={2, 5, 7},
-            restriction_idx_key=restriction_idx_key,
-        )
-
-        assert cluster_table.count() == 3
-        assert {
-            row[restriction_idx_key]
-            for row in cluster_table.select(
-                cluster_table[restriction_idx_key]
-            ).collect()
-        } == {2, 5, 7}
-
     def test_cluster_in_table_with_chunk(self):
         table_path = "unit_test.test_cluster_chunk"
 
@@ -653,6 +605,50 @@ class TestGoldClusterizer:
             .collect()
         )
         assert {row["idx"] for row in clustered} == {2, 5, 7}
+
+    def test_cluster_in_table_with_invalid_restriction_idx_key(self):
+        table_path = "unit_test.test_cluster_invalid_restriction_idx_key"
+        clusterizer = GoldClusterizer(
+            table_path=table_path,
+            clustering_tool=GoldRandomClusteringTool(random_state=0),
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="restriction_idx_key must be either 'idx' or 'idx_vector'",
+        ):
+            clusterizer.cluster_in_table(
+                DummyDataset([]),
+                n_clusters=2,
+                restrict_to={0},
+                restriction_idx_key="invalid",
+            )
+
+        with pytest.raises(pxt.Error):
+            pxt.get_table(table_path)
+
+    def test_cluster_in_table_with_valid_restriction_idx_key(self):
+        table_path = "unit_test.test_cluster_restrict_idx"
+        dataset = DummyDataset(
+            [{"vectorized": torch.rand(4), "idx": idx} for idx in range(10)]
+        )
+        clusterizer = GoldClusterizer(
+            table_path=table_path,
+            clustering_tool=GoldRandomClusteringTool(random_state=0),
+            batch_size=5,
+        )
+
+        cluster_table = clusterizer.cluster_in_table(
+            dataset,
+            n_clusters=3,
+            restrict_to={2, 5, 7},
+            restriction_idx_key="idx",
+        )
+
+        assert cluster_table.count() == 3
+        assert {
+            row["idx"] for row in cluster_table.select(cluster_table.idx).collect()
+        } == {2, 5, 7}
 
     def test_cluster_in_table_with_reducer(self):
         table_path = "unit_test.test_cluster_reducer"

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -261,6 +261,47 @@ class TestGoldSelector:
         with pytest.raises(ValueError, match="select_size must be a positive integer"):
             selector.select_in_table(dataset, select_size=0, value="train")
 
+    def test_select_in_table_with_invalid_restriction_idx_key(self):
+        table_path = "unit_test.test_select_invalid_restriction_idx_key"
+        selector = GoldSelector(table_path=table_path)
+
+        with pytest.raises(
+            ValueError,
+            match="restriction_idx_key must be either 'idx' or 'idx_vector'",
+        ):
+            selector.select_in_table(
+                DummyDataset([]),
+                select_size=1,
+                value="train",
+                restrict_to={0},
+                restriction_idx_key="invalid",
+            )
+
+        with pytest.raises(Error):
+            pxt.get_table(table_path)
+
+    @pytest.mark.parametrize("restriction_idx_key", ["idx", "idx_vector"])
+    def test_select_in_table_with_valid_restriction_idx_key(self, restriction_idx_key):
+        table_path = f"unit_test.test_select_restrict_{restriction_idx_key}"
+        dataset = DummyDataset(
+            [{"vectorized": torch.rand(5), "idx": idx} for idx in range(10)]
+        )
+        selector = GoldSelector(table_path=table_path, batch_size=5)
+
+        selection_table = selector.select_in_table(
+            dataset,
+            select_size=2,
+            value="train",
+            restrict_to={2, 5, 7},
+            restriction_idx_key=restriction_idx_key,
+        )
+
+        selected = selection_table.where(
+            selection_table[selector.selection_key] == "train"
+        ).collect()
+        assert len(selected) == 2
+        assert {row[restriction_idx_key] for row in selected} <= {2, 5, 7}
+
     def test_select_in_table_from_dataset_with_ratio(self):
         table_path = "unit_test.test_select_from_dataset"
 

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -242,25 +242,6 @@ class TestGoldSelector:
         assert len(selected_indices_2) == 20
         assert selected_indices_1.issubset(selected_indices_2)
 
-    def test_select_in_table_with_wrong_size(self):
-        table_path = "unit_test.test_select_from_dataset"
-
-        dataset = DummyDataset(
-            [{"vectorized": torch.rand(5), "idx": idx} for idx in range(100)]
-        )
-
-        selector = GoldSelector(
-            table_path=table_path, allow_existing=True, batch_size=10, max_batches=None
-        )
-
-        with pytest.raises(
-            ValueError, match="When select_size is a float, it must be in the range"
-        ):
-            selector.select_in_table(dataset, select_size=1.1, value="train")
-
-        with pytest.raises(ValueError, match="select_size must be a positive integer"):
-            selector.select_in_table(dataset, select_size=0, value="train")
-
     def test_select_in_table_with_invalid_restriction_idx_key(self):
         table_path = "unit_test.test_select_invalid_restriction_idx_key"
         selector = GoldSelector(table_path=table_path)
@@ -280,9 +261,8 @@ class TestGoldSelector:
         with pytest.raises(Error):
             pxt.get_table(table_path)
 
-    @pytest.mark.parametrize("restriction_idx_key", ["idx", "idx_vector"])
-    def test_select_in_table_with_valid_restriction_idx_key(self, restriction_idx_key):
-        table_path = f"unit_test.test_select_restrict_{restriction_idx_key}"
+    def test_select_in_table_with_valid_restriction_idx_key(self):
+        table_path = "unit_test.test_select_restrict_idx"
         dataset = DummyDataset(
             [{"vectorized": torch.rand(5), "idx": idx} for idx in range(10)]
         )
@@ -293,14 +273,33 @@ class TestGoldSelector:
             select_size=2,
             value="train",
             restrict_to={2, 5, 7},
-            restriction_idx_key=restriction_idx_key,
+            restriction_idx_key="idx",
         )
 
         selected = selection_table.where(
             selection_table[selector.selection_key] == "train"
         ).collect()
         assert len(selected) == 2
-        assert {row[restriction_idx_key] for row in selected} <= {2, 5, 7}
+        assert {row["idx"] for row in selected} <= {2, 5, 7}
+
+    def test_select_in_table_with_wrong_size(self):
+        table_path = "unit_test.test_select_from_dataset"
+
+        dataset = DummyDataset(
+            [{"vectorized": torch.rand(5), "idx": idx} for idx in range(100)]
+        )
+
+        selector = GoldSelector(
+            table_path=table_path, allow_existing=True, batch_size=10, max_batches=None
+        )
+
+        with pytest.raises(
+            ValueError, match="When select_size is a float, it must be in the range"
+        ):
+            selector.select_in_table(dataset, select_size=1.1, value="train")
+
+        with pytest.raises(ValueError, match="select_size must be a positive integer"):
+            selector.select_in_table(dataset, select_size=0, value="train")
 
     def test_select_in_table_from_dataset_with_ratio(self):
         table_path = "unit_test.test_select_from_dataset"


### PR DESCRIPTION
## Summary

Validate `restriction_idx_key` in `GoldSelector.select_in_table` and
`GoldClusterizer.cluster_in_table`.

Only `idx` and `idx_vector` are accepted, so invalid values now fail early
with a clear `ValueError` instead of producing downstream table/index errors.

## Changes

- validate `restriction_idx_key` in selector and clusterizer entry points
- add regression tests for invalid keys
- verify both `idx` and `idx_vector` remain supported
- ensure invalid input fails before PixelTable setup

## Verification

- `pytest tests/test_select.py tests/test_clusterize.py -q` — 103 passed
- `pytest tests/ -q` — 447 passed
- `ruff check .` — passed
- `ruff format --check .` — passed
- `mypy .` — passed
- `git diff --check` — passed

Fixes #318

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates the `restriction_idx_key` argument in `GoldSelector.select_in_table` and `GoldClusterizer.cluster_in_table` so invalid values fail early with a clear `ValueError` instead of downstream table/index errors.

- Only `'idx'` and `'idx_vector'` are accepted.
- Regression tests confirm invalid keys fail before table creation and valid keys still work.

<sup>Written for commit f48670a4cb7ee0019cb7decff4a32ecbdef5d3e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/goldener-data/goldener/pull/319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

