### PR TITLE
Enforce type annotations on all function definitions

### DIFF
--- a/goldener/embed.py
+++ b/goldener/embed.py
@@ -267,7 +267,7 @@ class GoldTorchEmbeddingTool(GoldEmbeddingTool):
         embeddings = self.embed(x)
         return self.fusion.fuse_embeddings(embeddings, self._layers, self._channel_pos)
 
-    def __del__(self):
+    def __del__(self) -> None:
         """Remove all registered hooks when the embedder is deleted."""
         for handle in self._hooks.values():
             handle.remove()

--- a/goldener/split.py
+++ b/goldener/split.py
@@ -276,7 +276,7 @@ class GoldSplitter:
         self._sets = sets
 
     @property
-    def clustering_enable(self):
+    def clustering_enable(self) -> bool:
         return self.clusterizer is not None and self.n_clusters > 1
 
     @staticmethod

--- a/goldener/torch_utils.py
+++ b/goldener/torch_utils.py
@@ -144,13 +144,13 @@ class ResetableTorchIterableDataset(torch.utils.data.IterableDataset):
         self.data_iterable = data_iterable
         self._data_iterator: Iterator[Any] | None = iter(self.data_iterable)
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[Any]:
         """Return the iterator object."""
         if self._data_iterator is None:
             self._data_iterator = iter(self.data_iterable)
         return self
 
-    def __next__(self):
+    def __next__(self) -> Any:
         """Return the next item from the iterator."""
         # __iter__ always runs before __next__ in the iterator protocol and
         # re-creates _data_iterator if it was exhausted, so it is never None
@@ -162,7 +162,7 @@ class ResetableTorchIterableDataset(torch.utils.data.IterableDataset):
             self._data_iterator = None
             raise
 
-    def reset(self):
+    def reset(self) -> None:
         """Reset the iterator to the beginning of the dataset."""
         self._data_iterator = iter(self.data_iterable)
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,7 @@
 [mypy]
 mypy_path = stubs
 explicit_package_bases = True
+disallow_untyped_defs = True
 exclude = examples
 warn_unused_ignores = True
 warn_redundant_casts = True


### PR DESCRIPTION
Closes #263.

Mypy now rejects untyped function definitions in the Goldener package.
The remaining iterator, cleanup, and splitter methods include explicit return annotations.