### PR TITLE
Match scikit-learn split populations

### DIFF
--- a/goldener/select.py
+++ b/goldener/select.py
@@ -1693,11 +1693,11 @@ class GoldSelector:
             restrict_to=restrict_to,
             restriction_idx_key=restriction_idx_key,
         )
-        if available_samples_for_selection_count < (
-            select_count - current_selected_count
-        ):
+        still_to_select = select_count - current_selected_count
+        if available_samples_for_selection_count < still_to_select:
             raise ValueError(
-                "Cannot select more unique data points than available in the dataset."
+                f"Cannot select more unique data points ({still_to_select}) "
+                f"than still available in the dataset ({available_samples_for_selection_count})."
             )
 
         # The coresubset selection is done from all the vectors (after filtering) of all data points

--- a/goldener/split.py
+++ b/goldener/split.py
@@ -435,11 +435,33 @@ class GoldSplitter:
         if sample_count is not None:
             check_sets_validity(self._sets, total=sample_count, force_max=True)
 
-        # select data for all sets
+        # Round non-final ratios down while reserving one sample for each
+        # remaining set, then assign the remainder to the final set.
+        set_counts = []
+        remaining_count = sample_count
         for idx_set, gold_set in enumerate(self._sets):
-            set_count = get_sampling_count_from_size(
-                sampling_size=gold_set.size, total_size=sample_count
-            )
+            remaining_sets = len(self._sets) - idx_set - 1
+            if remaining_sets == 0:
+                set_count = remaining_count
+            else:
+                requested_count = get_sampling_count_from_size(
+                    sampling_size=gold_set.size, total_size=sample_count
+                )
+                set_count = min(
+                    requested_count,
+                    remaining_count - remaining_sets,
+                )
+
+            if set_count <= 0:
+                raise ValueError(
+                    f"Not enough data to split among {len(self._sets)} sets."
+                )
+
+            set_counts.append(set_count)
+            remaining_count -= set_count
+
+        # select data for all sets
+        for idx_set, (gold_set, set_count) in enumerate(zip(self._sets, set_counts)):
             already_selected_count = self.selector.get_selection_count(
                 selection_table,
                 selection_key=self.selector.selection_key,

--- a/goldener/split.py
+++ b/goldener/split.py
@@ -435,33 +435,23 @@ class GoldSplitter:
         if sample_count is not None:
             check_sets_validity(self._sets, total=sample_count, force_max=True)
 
-        # Round non-final ratios down while reserving one sample for each
-        # remaining set, then assign the remainder to the final set.
-        set_counts = []
+        # select data for all sets
         remaining_count = sample_count
         for idx_set, gold_set in enumerate(self._sets):
-            remaining_sets = len(self._sets) - idx_set - 1
-            if remaining_sets == 0:
+            if idx_set == len(self._sets) - 1:
                 set_count = remaining_count
             else:
-                requested_count = get_sampling_count_from_size(
+                set_count = get_sampling_count_from_size(
                     sampling_size=gold_set.size, total_size=sample_count
                 )
-                set_count = min(
-                    requested_count,
-                    remaining_count - remaining_sets,
-                )
+                remaining_count -= set_count
 
             if set_count <= 0:
                 raise ValueError(
-                    f"Not enough data to split among {len(self._sets)} sets."
+                    f"Not enough data to split among {len(self._sets)} sets. "
+                    f"Last set '{gold_set.name}' has no remaining samples to select from."
                 )
 
-            set_counts.append(set_count)
-            remaining_count -= set_count
-
-        # select data for all sets
-        for idx_set, (gold_set, set_count) in enumerate(zip(self._sets, set_counts)):
             already_selected_count = self.selector.get_selection_count(
                 selection_table,
                 selection_key=self.selector.selection_key,
@@ -512,7 +502,8 @@ class GoldSplitter:
                 )
                 if not_yet_selected_count == 0 and already_in_set_count == 0:
                     raise ValueError(
-                        f"Not enough data to split among {len(self._sets)} sets."
+                        f"Not enough data to split among {len(self._sets)} sets. "
+                        f"Last set '{gold_set.name}' has no remaining samples to select from."
                     )
 
                 if (already_in_set_count + not_yet_selected_count) != set_count:

--- a/goldener/utils.py
+++ b/goldener/utils.py
@@ -322,8 +322,8 @@ def get_sampling_count_from_size(
 
     Args:
         sampling_size: The sampling size (can be int or float). If int, it represents the exact number of samples
-        and it is required to be less than total_size. If float, it represents the fraction of total size and it
-        is required to be in the range (0.0, 1.0].
+        and it is required to be less than total_size. If float, it represents the fraction of total size, rounded
+        down with a minimum of one sample, and it is required to be in the range (0.0, 1.0].
         total_size: The total size of the data (Optional, required if sampling_size is float).
 
     Returns:
@@ -351,7 +351,7 @@ def get_sampling_count_from_size(
     if total_size is None:
         raise ValueError("Total size must be provided when sampling size is a float.")
 
-    return math.ceil(sampling_size * total_size)
+    return max(1, math.floor(sampling_size * total_size))
 
 
 def transform_batch_from_multiple_to_binarized_targets(

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -3,6 +3,7 @@ import pytest
 import torch
 
 import pixeltable as pxt
+from sklearn.model_selection import train_test_split
 from torch.utils.data import Dataset
 
 from goldener.clusterize import GoldClusterizer, GoldRandomClusteringTool
@@ -524,6 +525,82 @@ class TestGoldSplitter:
 
         with pytest.raises(pxt.Error):
             pxt.get_table(basic_splitter.vectorizer.table_path)
+
+    def test_split_population_matches_sklearn(self, selector):
+        sample_count = 11
+        train_ratio = 0.8
+        splitter = GoldSplitter(
+            sets=[
+                GoldSet(name="train", size=train_ratio),
+                GoldSet(name="val", size=1 - train_ratio),
+            ],
+            selector=selector,
+        )
+
+        split_table = splitter.split_in_table(
+            to_split=DummyDataset(
+                [
+                    {
+                        "vectorized": torch.rand(4),
+                        "idx": idx,
+                        "label": "dummy",
+                    }
+                    for idx in range(sample_count)
+                ]
+            )
+        )
+        split_indices = splitter.get_split_indices(
+            split_table,
+            selection_key=splitter.selector.selection_key,
+            idx_key="idx",
+        )
+        sklearn_train, sklearn_val = train_test_split(
+            range(sample_count), train_size=train_ratio, shuffle=False
+        )
+
+        assert len(split_indices["train"]) == len(sklearn_train)
+        assert len(split_indices["val"]) == len(sklearn_val)
+
+    @pytest.mark.parametrize(
+        "sample_count,set_sizes,expected_counts",
+        [
+            (11, (0.5, 0.3, 0.2), {"train": 5, "val": 3, "test": 3}),
+            (3, (0.9, 0.05, 0.05), {"train": 1, "val": 1, "test": 1}),
+        ],
+    )
+    def test_split_population_with_multiple_sets(
+        self, selector, sample_count, set_sizes, expected_counts
+    ):
+        splitter = GoldSplitter(
+            sets=[
+                GoldSet(name="train", size=set_sizes[0]),
+                GoldSet(name="val", size=set_sizes[1]),
+                GoldSet(name="test", size=set_sizes[2]),
+            ],
+            selector=selector,
+        )
+
+        split_table = splitter.split_in_table(
+            to_split=DummyDataset(
+                [
+                    {
+                        "vectorized": torch.rand(4),
+                        "idx": idx,
+                        "label": "dummy",
+                    }
+                    for idx in range(sample_count)
+                ]
+            )
+        )
+        split_indices = splitter.get_split_indices(
+            split_table,
+            selection_key=splitter.selector.selection_key,
+            idx_key="idx",
+        )
+
+        assert {
+            name: len(indices) for name, indices in split_indices.items()
+        } == expected_counts
 
     def test_split_in_table_from_dataset_with_restart(self, basic_splitter):
         dataset = DummyDataset(

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -135,7 +135,7 @@ class TestGoldSplitter:
         pxt.get_table(basic_splitter.vectorizer.table_path)
         pxt.get_table(basic_splitter.selector.table_path)
 
-    def test_split_in_table_from_table(self, basic_splitter):
+    def test_split_in_table_from_table(self, descriptor, selector, vectorizer):
         src_path = "unit_test.test_split_in_table"
         src_table = pxt.create_table(
             src_path,
@@ -150,17 +150,113 @@ class TestGoldSplitter:
             if_exists="replace_force",
         )
 
-        split_table = basic_splitter.split_in_table(to_split=src_table)
+        splitter = GoldSplitter(
+            sets=[
+                GoldSet(name="train", size=0.5),
+                GoldSet(name="val", size=0.3),
+                GoldSet(name="test", size=0.2),
+            ],
+            descriptor=descriptor,
+            selector=selector,
+            vectorizer=vectorizer,
+        )
 
-        splitted = basic_splitter.get_split_indices(
+        split_table = splitter.split_in_table(to_split=src_table)
+
+        splitted = splitter.get_split_indices(
             split_table,
-            selection_key=basic_splitter.selector.selection_key,
+            selection_key=splitter.selector.selection_key,
             idx_key="idx",
         )
 
-        assert len(splitted) == 2
+        assert len(splitted) == 3
         assert len(splitted["train"]) == 5
-        assert len(splitted["val"]) == 5
+        assert len(splitted["val"]) == 3
+        assert len(splitted["test"]) == 2
+
+    def test_split_population_matches_sklearn(self, selector):
+        sample_count = 11
+        train_ratio = 0.8
+        splitter = GoldSplitter(
+            sets=[
+                GoldSet(name="train", size=train_ratio),
+                GoldSet(name="val", size=1 - train_ratio),
+            ],
+            selector=selector,
+        )
+
+        dataset = DummyDataset(
+            [
+                {
+                    "vectorized": torch.rand(4),
+                    "idx": idx,
+                    "label": "dummy",
+                }
+                for idx in range(sample_count)
+            ]
+        )
+        split_table = splitter.split_in_table(to_split=dataset)
+        split_indices = splitter.get_split_indices(
+            split_table,
+            selection_key=splitter.selector.selection_key,
+            idx_key="idx",
+        )
+        sklearn_train, sklearn_val = train_test_split(
+            range(sample_count), train_size=train_ratio, shuffle=False
+        )
+
+        assert len(split_indices["train"]) == len(sklearn_train)
+        assert len(split_indices["val"]) == len(sklearn_val)
+
+        repeated_table = splitter.split_in_table(to_split=dataset)
+        repeated_indices = splitter.get_split_indices(
+            repeated_table,
+            selection_key=splitter.selector.selection_key,
+            idx_key="idx",
+        )
+        assert repeated_indices == split_indices
+
+    def test_split_population_with_multiple_sets_failures(
+        self,
+        selector,
+    ):
+        dataset = DummyDataset(
+            [
+                {
+                    "vectorized": torch.rand(4),
+                    "idx": idx,
+                    "label": "dummy",
+                }
+                for idx in range(3)
+            ]
+        )
+
+        # failure before the last set
+        with pytest.raises(ValueError, match="Cannot select more unique data points"):
+            GoldSplitter(
+                sets=[
+                    GoldSet(name="train", size=0.9),
+                    GoldSet(name="val", size=0.05),
+                    GoldSet(name="test", size=0.025),
+                    GoldSet(name="cal", size=0.025),
+                ],
+                selector=selector,
+            ).split_in_table(
+                to_split=dataset,
+            )
+
+        # failure on the last set
+        with pytest.raises(ValueError, match="Not enough data to split among"):
+            GoldSplitter(
+                sets=[
+                    GoldSet(name="train", size=0.9),
+                    GoldSet(name="val", size=0.05),
+                    GoldSet(name="test", size=0.05),
+                ],
+                selector=selector,
+            ).split_in_table(
+                to_split=dataset,
+            )
 
     def test_split_with_label(self, descriptor, selector, vectorizer):
         sets = [
@@ -525,82 +621,6 @@ class TestGoldSplitter:
 
         with pytest.raises(pxt.Error):
             pxt.get_table(basic_splitter.vectorizer.table_path)
-
-    def test_split_population_matches_sklearn(self, selector):
-        sample_count = 11
-        train_ratio = 0.8
-        splitter = GoldSplitter(
-            sets=[
-                GoldSet(name="train", size=train_ratio),
-                GoldSet(name="val", size=1 - train_ratio),
-            ],
-            selector=selector,
-        )
-
-        split_table = splitter.split_in_table(
-            to_split=DummyDataset(
-                [
-                    {
-                        "vectorized": torch.rand(4),
-                        "idx": idx,
-                        "label": "dummy",
-                    }
-                    for idx in range(sample_count)
-                ]
-            )
-        )
-        split_indices = splitter.get_split_indices(
-            split_table,
-            selection_key=splitter.selector.selection_key,
-            idx_key="idx",
-        )
-        sklearn_train, sklearn_val = train_test_split(
-            range(sample_count), train_size=train_ratio, shuffle=False
-        )
-
-        assert len(split_indices["train"]) == len(sklearn_train)
-        assert len(split_indices["val"]) == len(sklearn_val)
-
-    @pytest.mark.parametrize(
-        "sample_count,set_sizes,expected_counts",
-        [
-            (11, (0.5, 0.3, 0.2), {"train": 5, "val": 3, "test": 3}),
-            (3, (0.9, 0.05, 0.05), {"train": 1, "val": 1, "test": 1}),
-        ],
-    )
-    def test_split_population_with_multiple_sets(
-        self, selector, sample_count, set_sizes, expected_counts
-    ):
-        splitter = GoldSplitter(
-            sets=[
-                GoldSet(name="train", size=set_sizes[0]),
-                GoldSet(name="val", size=set_sizes[1]),
-                GoldSet(name="test", size=set_sizes[2]),
-            ],
-            selector=selector,
-        )
-
-        split_table = splitter.split_in_table(
-            to_split=DummyDataset(
-                [
-                    {
-                        "vectorized": torch.rand(4),
-                        "idx": idx,
-                        "label": "dummy",
-                    }
-                    for idx in range(sample_count)
-                ]
-            )
-        )
-        split_indices = splitter.get_split_indices(
-            split_table,
-            selection_key=splitter.selector.selection_key,
-            idx_key="idx",
-        )
-
-        assert {
-            name: len(indices) for name, indices in split_indices.items()
-        } == expected_counts
 
     def test_split_in_table_from_dataset_with_restart(self, basic_splitter):
         dataset = DummyDataset(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -180,14 +180,20 @@ class TestGetSamplingCountFromSize:
         )
         assert count == 5
 
-    def test_float_sampling_size(self):
-        sampling_size = 0.5
-        total_size = 10
+    @pytest.mark.parametrize(
+        "sampling_size,total_size,expected_count",
+        [
+            (0.5, 10, 5),
+            (0.8, 11, 8),
+            (0.001, 2, 1),
+        ],
+    )
+    def test_float_sampling_size(self, sampling_size, total_size, expected_count):
         count = get_sampling_count_from_size(
             sampling_size,
             total_size,
         )
-        assert count == 5
+        assert count == expected_count
 
     def test_invalid_integer_sampling_raises(self):
         sampling_size = 0


### PR DESCRIPTION
Closes #109.

Fractional set sizes now round down to match scikit-learn while
preserving at least one sample per set. The final set receives all
remaining samples.

Tests cover scikit-learn parity, multi-set remainder allocation, and
small populations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Matches scikit-learn's split population sizes by rounding fractional set sizes down instead of up, guaranteeing at least one sample per set, and assigning all remaining samples to the final set. Splitting the same data twice now yields identical sets. Closes #109.

- Raises a `ValueError` showing the missing sample counts when there aren't enough samples to give each set at least one.
- Adds tests for scikit-learn parity, multi-set remainder allocation, small populations, and repeated-call determinism.

<sup>Written for commit 7c39024354187641b9fa03337eccd1e91f40cd01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/goldener-data/goldener/pull/321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

