### PR TITLE
test: Add a unit test for the usage of restrict_to and restriction_idx_key in select_in_dataset of GoldSelector

### DIFF
--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -687,6 +687,88 @@ class TestGoldSelector:
 
         dataset.keep_cache = False
 
+    def test_select_in_dataset_with_restrict_to(self):
+        table_path = "unit_test.test_restrict_to"
+
+        dataset = DummyDataset(
+            [
+                {"vectorized": torch.rand(5), "idx": idx, "idx_vector": idx}
+                for idx in range(20)
+            ]
+        )
+
+        selector = GoldSelector(
+            table_path=table_path, allow_existing=False, batch_size=10, max_batches=None
+        )
+
+        dataset = selector.select_in_dataset(
+            dataset, select_size=3, value="train", restrict_to={0, 1, 2, 3, 4}
+        )
+
+        selected_indices = set()
+        for item in dataset:
+            if item["selected"] == "train":
+                selected_indices.add(item["idx_vector"])
+
+        assert len(selected_indices) == 3
+        assert selected_indices.issubset({0, 1, 2, 3, 4})
+
+        dataset.keep_cache = False
+
+    def test_select_in_dataset_with_restriction_idx_key(self):
+        table_path = "unit_test.test_restriction_idx_key"
+
+        dataset = DummyDataset(
+            [
+                {"vectorized": torch.rand(5), "idx": idx, "idx_vector": idx + 100}
+                for idx in range(20)
+            ]
+        )
+        selector = GoldSelector(
+            table_path=table_path, allow_existing=False, batch_size=10, max_batches=None
+        )
+        dataset = selector.select_in_dataset(
+            dataset,
+            select_size=3,
+            value="train",
+            restrict_to={0, 1, 4},
+            restriction_idx_key="idx",
+        )
+        selected_indices = set()
+        selected_idx_vector = set()
+        for item in dataset:
+            if item["selected"] == "train":
+                assert item["idx_vector"] == item["idx"] + 100
+                selected_indices.add(item["idx"])
+                selected_idx_vector.add(item["idx_vector"])
+
+        assert len(selected_indices) == 3
+        assert selected_indices.issubset({0, 1, 4})
+        assert selected_idx_vector.issubset({100, 101, 104})
+
+        dataset.keep_cache = False
+
+    def test_select_in_dataset_with_restrict_to_exceeding_size(self):
+        # restrict_to pool size 3, select_size=5 → ValueError expect karo
+        table_path = "unit_test.test_restrict_to"
+
+        dataset = DummyDataset(
+            [
+                {"vectorized": torch.rand(5), "idx": idx, "idx_vector": idx}
+                for idx in range(20)
+            ]
+        )
+        selector = GoldSelector(
+            table_path=table_path, allow_existing=False, batch_size=10, max_batches=None
+        )
+
+        with pytest.raises(
+            ValueError, match="cannot be greater than the total number of samples"
+        ):
+            selector.select_in_dataset(
+                dataset, select_size=5, value="train", restrict_to={0, 1, 2}
+            )
+
     def test_select_in_table_from_dataset_with_already_selected(self):
         table_path = "unit_test.test_select_from_dataset"
 

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -781,7 +781,6 @@ class TestGoldSelector:
         dataset.keep_cache = False
 
     def test_select_in_dataset_with_restrict_to_exceeding_size(self):
-        # restrict_to pool size 3, select_size=5 → ValueError expect karo
         table_path = "unit_test.test_restrict_to"
 
         dataset = DummyDataset(

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -687,7 +687,7 @@ class TestGoldSelector:
 
         dataset.keep_cache = False
 
-    def test_select_in_dataset_with_restrict_to(self):
+    def test_select_from_dataset_with_restrict_to(self):
         table_path = "unit_test.test_restrict_to"
 
         dataset = DummyDataset(
@@ -714,6 +714,38 @@ class TestGoldSelector:
         assert selected_indices.issubset({0, 1, 2, 3, 4})
 
         dataset.keep_cache = False
+
+    def test_select_from_table_with_restrict_to(self):
+        src_path = "unit_test.src_table_restrict"
+        src_table = pxt.create_table(
+            src_path,
+            source=[
+                {
+                    "vectorized": torch.rand(5).numpy().astype(np.float32),
+                    "idx": idx,
+                    "idx_vector": idx,
+                }
+                for idx in range(10)
+            ],
+            if_exists="replace_force",
+            primary_key="idx_vector",
+        )
+
+        selector = GoldSelector(
+            table_path="unit_test.test_select_from_table_restrict", allow_existing=True
+        )
+
+        result_table = selector.select_in_table(
+            src_table, select_size=2, value="train", restrict_to={2, 5, 7}
+        )
+
+        assert result_table.count() == 10  # full table preserved
+
+        selected_indices = selector.get_selection_indices(
+            result_table, "train", selector.selection_key
+        )
+        assert len(selected_indices) == 2
+        assert selected_indices.issubset({2, 5, 7})
 
     def test_select_in_dataset_with_restriction_idx_key(self):
         table_path = "unit_test.test_restriction_idx_key"


### PR DESCRIPTION
## Closes #310

- select_in_dataset forwards restrict_to and restriction_idx_key to select_in_table, but neither parameter had dedicated unit test coverage in this file (only indirectly exercised via GoldSplitter).

## Tests added
- test_select_in_dataset_with_restrict_to — verifies selection is limited to the idx_vector values passed in restrict_to, not the full dataset.
- test_select_in_dataset_with_restriction_idx_key — verifies filtering happens on a custom key (idx) instead of the default idx_vector, and that idx/idx_vector mapping stays correct for selected samples.
- test_select_in_dataset_with_restrict_to_exceeding_size — verifies a ValueError is raised when select_size exceeds the size of the restricted pool (not the full dataset).

- All 61 tests in tests/test_select.py pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds unit test coverage for `restrict_to` and `restriction_idx_key` in `GoldSelector.select_in_dataset` and `select_in_table`, closing #310.

- Verifies selection is limited to the passed `restrict_to` pool rather than the full dataset for both methods.
- Verifies filtering works on a custom `restriction_idx_key` and keeps the `idx`/`idx_vector` mapping correct for selected samples.
- Verifies a `ValueError` is raised when `select_size` exceeds the restricted pool size.
- Confirms `select_in_table` preserves the full source table while marking only the restricted pool.
- Updates are test-only; all 61 tests in `tests/test_select.py` pass.

<sup>Written for commit 77a0d7cb2e4c4c63dee91bc9f6905f96d26c766b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/goldener-data/goldener/pull/322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

