### PR TITLE
test(vectorizer): fix method name in TestGoldVectorizer

### DIFF
--- a/tests/test_vectorize.py
+++ b/tests/test_vectorize.py
@@ -617,7 +617,7 @@ class TestGoldVectorizer:
         for row in out_table.collect():
             assert row["vectorized"] is not None
 
-    def test_vectorize_from_table_with_restrict_to_from_table(self):
+    def test_vectorize_from_table_with_restrict_to(self):
         src_path = "unit_test.src_vectorize_restrict"
         gv = GoldVectorizer(
             table_path="unit_test.vectorize_restrict_from_table",


### PR DESCRIPTION
Fixes #324 by removing redundant 'from_table' suffix from test method name.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #324 by renaming the test method in `tests/test_vectorize.py` to drop the redundant `from_table` suffix. This is a test-only change with no runtime impact.

<sup>Written for commit 62b83870a55474dd9a29adc9db00b2d9e82f60b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/goldener-data/goldener/pull/325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

