### PR TITLE
Make the GoldSplitter match sklearn `train_test_split` output (ease comparison with random sampling)

### DIFF
--- a/goldener/select.py
+++ b/goldener/select.py
@@ -1693,11 +1693,11 @@ class GoldSelector:
             restrict_to=restrict_to,
             restriction_idx_key=restriction_idx_key,
         )
-        if available_samples_for_selection_count < (
-            select_count - current_selected_count
-        ):
+        still_to_select = select_count - current_selected_count
+        if available_samples_for_selection_count < still_to_select:
             raise ValueError(
-                "Cannot select more unique data points than available in the dataset."
+                f"Cannot select more unique data points ({still_to_select}) "
+                f"than still available in the dataset ({available_samples_for_selection_count})."
             )
 
         # The coresubset selection is done from all the vectors (after filtering) of all data points

--- a/goldener/split.py
+++ b/goldener/split.py
@@ -490,7 +490,8 @@ class GoldSplitter:
                 )
                 if not_yet_selected_count == 0 and already_in_set_count == 0:
                     raise ValueError(
-                        f"Not enough data to split among {len(self._sets)} sets."
+                        f"Not enough data to split among {len(self._sets)} sets. "
+                        f"Last set '{gold_set.name}' has no remaining samples to select from."
                     )
 
                 if (already_in_set_count + not_yet_selected_count) != set_count:

--- a/goldener/utils.py
+++ b/goldener/utils.py
@@ -322,8 +322,8 @@ def get_sampling_count_from_size(
 
     Args:
         sampling_size: The sampling size (can be int or float). If int, it represents the exact number of samples
-        and it is required to be less than total_size. If float, it represents the fraction of total size and it
-        is required to be in the range (0.0, 1.0].
+        and it is required to be less than total_size. If float, it represents the fraction of total size, rounded
+        down with a minimum of one sample, and it is required to be in the range (0.0, 1.0].
         total_size: The total size of the data (Optional, required if sampling_size is float).
 
     Returns:

--- a/goldener/utils.py
+++ b/goldener/utils.py
@@ -351,7 +351,7 @@ def get_sampling_count_from_size(
     if total_size is None:
         raise ValueError("Total size must be provided when sampling size is a float.")
 
-    return math.ceil(sampling_size * total_size)
+    return max(1, math.floor(sampling_size * total_size))
 
 
 def transform_batch_from_multiple_to_binarized_targets(

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -3,6 +3,7 @@ import pytest
 import torch
 
 import pixeltable as pxt
+from sklearn.model_selection import train_test_split
 from torch.utils.data import Dataset
 
 from goldener.clusterize import GoldClusterizer, GoldRandomClusteringTool
@@ -134,7 +135,7 @@ class TestGoldSplitter:
         pxt.get_table(basic_splitter.vectorizer.table_path)
         pxt.get_table(basic_splitter.selector.table_path)
 
-    def test_split_in_table_from_table(self, basic_splitter):
+    def test_split_in_table_from_table(self, descriptor, selector, vectorizer):
         src_path = "unit_test.test_split_in_table"
         src_table = pxt.create_table(
             src_path,
@@ -149,17 +150,106 @@ class TestGoldSplitter:
             if_exists="replace_force",
         )
 
-        split_table = basic_splitter.split_in_table(to_split=src_table)
+        splitter = GoldSplitter(
+            sets=[
+                GoldSet(name="train", size=0.5),
+                GoldSet(name="val", size=0.3),
+                GoldSet(name="test", size=0.2),
+            ],
+            descriptor=descriptor,
+            selector=selector,
+            vectorizer=vectorizer,
+        )
 
-        splitted = basic_splitter.get_split_indices(
+        split_table = splitter.split_in_table(to_split=src_table)
+
+        splitted = splitter.get_split_indices(
             split_table,
-            selection_key=basic_splitter.selector.selection_key,
+            selection_key=splitter.selector.selection_key,
             idx_key="idx",
         )
 
-        assert len(splitted) == 2
+        assert len(splitted) == 3
         assert len(splitted["train"]) == 5
-        assert len(splitted["val"]) == 5
+        assert len(splitted["val"]) == 3
+        assert len(splitted["test"]) == 2
+
+    def test_split_population_matches_sklearn(self, selector):
+        sample_count = 11
+        train_ratio = 0.8
+        splitter = GoldSplitter(
+            sets=[
+                GoldSet(name="train", size=train_ratio),
+                GoldSet(name="val", size=1 - train_ratio),
+            ],
+            selector=selector,
+        )
+
+        split_table = splitter.split_in_table(
+            to_split=DummyDataset(
+                [
+                    {
+                        "vectorized": torch.rand(4),
+                        "idx": idx,
+                        "label": "dummy",
+                    }
+                    for idx in range(sample_count)
+                ]
+            )
+        )
+        split_indices = splitter.get_split_indices(
+            split_table,
+            selection_key=splitter.selector.selection_key,
+            idx_key="idx",
+        )
+        sklearn_train, sklearn_val = train_test_split(
+            range(sample_count), train_size=train_ratio, shuffle=False
+        )
+
+        assert len(split_indices["train"]) == len(sklearn_train)
+        assert len(split_indices["val"]) == len(sklearn_val)
+
+    def test_split_population_with_multiple_sets_failures(
+        self,
+        selector,
+    ):
+        dataset = DummyDataset(
+            [
+                {
+                    "vectorized": torch.rand(4),
+                    "idx": idx,
+                    "label": "dummy",
+                }
+                for idx in range(3)
+            ]
+        )
+
+        # failure before the last set
+        with pytest.raises(ValueError, match="Cannot select more unique data points"):
+            GoldSplitter(
+                sets=[
+                    GoldSet(name="train", size=0.9),
+                    GoldSet(name="val", size=0.05),
+                    GoldSet(name="test", size=0.025),
+                    GoldSet(name="cal", size=0.025),
+                ],
+                selector=selector,
+            ).split_in_table(
+                to_split=dataset,
+            )
+
+        # failure on the last set
+        with pytest.raises(ValueError, match="Not enough data to split among"):
+            GoldSplitter(
+                sets=[
+                    GoldSet(name="train", size=0.9),
+                    GoldSet(name="val", size=0.05),
+                    GoldSet(name="test", size=0.05),
+                ],
+                selector=selector,
+            ).split_in_table(
+                to_split=dataset,
+            )
 
     def test_split_with_label(self, descriptor, selector, vectorizer):
         sets = [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -180,14 +180,20 @@ class TestGetSamplingCountFromSize:
         )
         assert count == 5
 
-    def test_float_sampling_size(self):
-        sampling_size = 0.5
-        total_size = 10
+    @pytest.mark.parametrize(
+        "sampling_size,total_size,expected_count",
+        [
+            (0.5, 10, 5),
+            (0.8, 11, 8),
+            (0.001, 2, 1),
+        ],
+    )
+    def test_float_sampling_size(self, sampling_size, total_size, expected_count):
         count = get_sampling_count_from_size(
             sampling_size,
             total_size,
         )
-        assert count == 5
+        assert count == expected_count
 
     def test_invalid_integer_sampling_raises(self):
         sampling_size = 0


### PR DESCRIPTION
closes #109 

This pull request introduces several improvements and bug fixes to the data splitting and sampling logic, along with expanded test coverage. The changes clarify error messages, adjust sampling behavior to better match expectations, and add new tests to ensure correctness in edge cases and alignment with `scikit-learn`'s splitting logic.

**Key changes:**

### Sampling logic and error handling

* The sampling count calculation in `get_sampling_count_from_size` was changed to use `math.floor` and always return at least 1, ensuring more intuitive and consistent splits, especially for small sample sizes. Tests were updated to cover various float sampling scenarios. [[1]](diffhunk://#diff-996a5e6a5c57e8a2806d8f5753ec8c8184cbf9766795fbafcc066c436f5af595L354-R354) [[2]](diffhunk://#diff-33c13e0b177bacd2f02e29bcb8aea5b49e7ce34901fd8f41fefb65defba1bd33L183-R196)
* Improved error messages in `_select_label` and `split_in_table` to provide clearer information about why selection or splitting failed, including more specific details about the number of samples requested and available. [[1]](diffhunk://#diff-bd9472afb5f4d1443584cbefe22523bc9c5581daa1ef19f08067fdcb0159e6e3L1696-R1700) [[2]](diffhunk://#diff-d1c1f9e2375dc6c25aaa7b9fb1f5b90b718704fe94d4bdd77ee731abca240d92R494)

### Test enhancements and coverage

* Added new tests in `test_split.py` to verify that splitting behavior matches `sklearn.model_selection.train_test_split` and to check for correct failure modes when not enough data is available for all requested sets.
* Updated the test for splitting from a table to use explicit construction of a `GoldSplitter` and to assert all expected sets and their sizes, increasing test robustness. [[1]](diffhunk://#diff-b158b85e51bb5d4e9aef95fa137e171e50ef7663b5f61d8e6494bdcab583630aL137-R138) [[2]](diffhunk://#diff-b158b85e51bb5d4e9aef95fa137e171e50ef7663b5f61d8e6494bdcab583630aL152-R252)
* Added import of `train_test_split` from `sklearn.model_selection` in the test suite to support new comparison tests.